### PR TITLE
Fix the link in the alpha warning

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -72,7 +72,7 @@
 
         <div id="alpha_warning" class="box">
           <h4>This stuff is alpha.</h4>
-          <p>Please do <strong>not</strong> consider this a stable service. We're still far from that! More info <a href='https://github.com/svenfuchs/travis/wiki'>here.</a></p>
+          <p>Please do <strong>not</strong> consider this a stable service. We're still far from that! More info <a href='https://github.com/travis-ci/travis-ci'>here.</a></p>
         </div>
 
         <div id="about" class="box">


### PR DESCRIPTION
Refer to https://github.com/travis-ci/travis-ci instead of https://github.com/svenfuchs/travis, which simply states: "Travis was moved to the travis-ci organization"
