### PR TITLE
Don't create a build for commits in the gh_pages branch of a repository.

### DIFF
--- a/app/controllers/builds_controller.rb
+++ b/app/controllers/builds_controller.rb
@@ -14,9 +14,11 @@ class BuildsController < ApplicationController
   end
 
   def create
-    build.save!
-    enqueue!(build)
-    build.repository.update_attributes!(:last_built_at => Time.now) # TODO the build isn't actually started now
+    if build
+      build.save!
+      enqueue!(build)
+      build.repository.update_attributes!(:last_built_at => Time.now) # TODO the build isn't actually started now
+    end
     render :nothing => true
   end
 

--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -22,7 +22,8 @@ class Build < ActiveRecord::Base
       repository = Repository.find_or_create_by_github_repository(data.repository)
       number     = repository.builds.next_number
       attributes = data.builds.last.to_hash.merge(:number => number, :github_payload => payload)
-      repository.builds.create(attributes)
+
+      attributes[:branch].match(/gh_pages/i) ? nil : repository.builds.create(attributes)
     end
 
     def next_number

--- a/test/integration/builds_controller_test.rb
+++ b/test/integration/builds_controller_test.rb
@@ -34,6 +34,12 @@ class BuildsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test 'POST to /builds (ping from github) does not create a build record when the branch is gh_pages' do
+    assert_no_difference('Build.count') do
+      post '/builds', { :payload => GITHUB_PAYLOADS['gh-pages-update'] }, 'HTTP_AUTHORIZATION' => credentials
+    end
+  end
+
   test 'PUT to /builds/:id configures the build and expands a given build matrix' do
     configure_from_worker!
     assert_build_matrix_configured

--- a/test/test_helpers/payloads.rb
+++ b/test/test_helpers/payloads.rb
@@ -22,6 +22,31 @@ GITHUB_PAYLOADS = {
       }
     }],
     "ref": "refs/heads/master"
+  }),
+
+  "gh-pages-update" => %({
+    "repository": {
+      "url": "http://github.com/svenfuchs/gem-release",
+      "name": "gem-release",
+      "owner": {
+        "email": "svenfuchs@artweb-design.de",
+        "name": "svenfuchs"
+      }
+    },
+    "commits": [{
+      "id":        "9854592",
+      "message":   "Bump to 0.0.15",
+      "timestamp": "2010-10-27 04:32:37",
+      "committer": {
+        "name":  "Sven Fuchs",
+        "email": "svenfuchs@artweb-design.de"
+      },
+      "author": {
+        "name":  "Christopher Floess",
+        "email": "chris@flooose.de"
+      }
+    }],
+    "ref": "refs/heads/gh_pages"
   })
 }
 

--- a/test/unit/build_test.rb
+++ b/test/unit/build_test.rb
@@ -29,6 +29,13 @@ class BuildTest < ActiveSupport::TestCase
     assert_equal GITHUB_PAYLOADS['gem-release'], build.github_payload
   end
 
+  test 'creating a Build from Github payload from a gh_pages branch' do
+    Repository.delete_all
+    Build.delete_all
+
+    assert_nil Build.create_from_github_payload(GITHUB_PAYLOADS['gh-pages-update'])
+  end
+
   test 'next_number (1)' do
     repository = Factory(:repository)
     assert_equal 1, repository.builds.next_number


### PR DESCRIPTION
I noticed that travis tries to build when a commit is made in the gh_pages branch of a repository. This branch contains only HTML or Jekyll data for the project page and should not be included in the build. 

This pull request contains code fixes and tests to prevent a new build from being created when the commit was made in the gh_pages branch.
