### PR TITLE
Fixed mailto links in build summary view.

### DIFF
--- a/markup/index.html
+++ b/markup/index.html
@@ -191,12 +191,12 @@
                 <dd class="finished_at timeago" title="2011-02-22T22:02:50Z">about 14 hours ago</dd>
                 <!-- <dt class="eta_label">ETA</dt><dd class="eta timeago" title="?">?</dd> -->
                 <dt>Committer</dt>
-                <dd class="committer"><a href="mailto://florian.hanke@gmail.com">Florian Hanke</a></dd>
+                <dd class="committer"><a href="mailto:florian.hanke@gmail.com">Florian Hanke</a></dd>
 
                 <dt>Duration</dt>
                 <dd class="duration" title="8">8 sec</dd>
                 <dt>Author</dt>
-                <dd class="author"><a href="mailto://florian.hanke@gmail.com">Florian Hanke</a></dd>
+                <dd class="author"><a href="mailto:florian.hanke@gmail.com">Florian Hanke</a></dd>
 
                 <dt>Message</dt>
                 <dd class="commit-message">+ 1.2.11, + Norway, Denmark.</dd>

--- a/public/javascripts/app/templates/build/summary.ms
+++ b/public/javascripts/app/templates/build/summary.ms
@@ -12,10 +12,10 @@
     <dt>Commit</dt>
     <dd class="commit-hash"><a href="http://github.com/{{repository/slug}}/commit/{{commit}}">{{commit}}{{#if branch}} ({{branch}}){{/if}}</a></dd>
     <dt>Author</dt>
-    <dd class="author"><a href="mailto://{{author_email}}">{{author_name}}</a></dd>
+    <dd class="author"><a href="mailto:{{author_email}}">{{author_name}}</a></dd>
     {{#if committer_name}}
       <dt>Committer</dt>
-      <dd class="committer"><a href="mailto://{{committer_email}}">{{committer_name}}</a></dd>
+      <dd class="committer"><a href="mailto:{{committer_email}}">{{committer_name}}</a></dd>
     {{/if}}
   </div>
 


### PR DESCRIPTION
I believe the mailto links had invalid syntax `mailto://<address>` instead of `mailto:<address>`.
