### PR TITLE
Allow syncing of data from github

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,13 +3,13 @@ class User < ActiveRecord::Base
 
   has_many :tokens
 
-  attr_accessible :name, :login, :email
+  attr_accessible :name, :login, :email, :github_id
 
   after_create :create_a_token
 
   def self.find_for_github_oauth(user_hash)
     data = user_hash['extra']['user_hash']
-    if user = User.find_by_login(data["login"])
+    if user = User.find_by_github_id(data["id"])
       user.update_attributes( User::user_data_from_github_data(data) )
       user
     else
@@ -18,7 +18,10 @@ class User < ActiveRecord::Base
   end
 
   def self.user_data_from_github_data(data)
-      data.slice(*%w{name login email})
+      data.slice!(*%w{id name login email})
+      data['github_id'] = data['id']
+      data.delete 'id'
+      data
   end
 
   def profile_image_hash

--- a/db/migrate/20110503150504_add_github_id_to_users_table.rb
+++ b/db/migrate/20110503150504_add_github_id_to_users_table.rb
@@ -1,0 +1,11 @@
+class AddGithubIdToUsersTable < ActiveRecord::Migration
+  def self.up
+    add_column :users , :github_id , :integer
+    add_index :users, :github_id
+  end
+
+  def self.down
+    remove_index :users , :github_id
+    remove_column :users, :github_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20110414131100) do
+ActiveRecord::Schema.define(:version => 20110503150504) do
 
   create_table "builds", :force => true do |t|
     t.integer  "repository_id"
@@ -83,8 +83,10 @@ ActiveRecord::Schema.define(:version => 20110414131100) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean  "is_admin",   :default => false
+    t.integer  "github_id"
   end
 
+  add_index "users", ["github_id"], :name => "index_users_on_github_id"
   add_index "users", ["login"], :name => "index_users_on_login", :unique => true
 
 end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -16,8 +16,8 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test 'user_data_from_github_data returns required data' do
-    github_data = {'name' => 'j_user', 'login' => 'j_user' , 'email' => 'j_user@email.com' , 'company' => 'ACME'}
-    returned_data = {'name' => 'j_user', 'login' => 'j_user' , 'email' => 'j_user@email.com' }
+    github_data = {'name' => 'j_user', 'login' => 'j_user' , 'email' => 'j_user@email.com' , 'company' => 'ACME', 'id' => '234423'}
+    returned_data = {'name' => 'j_user', 'login' => 'j_user' , 'email' => 'j_user@email.com', 'github_id' => '234423' }
 
     assert_equal returned_data , User::user_data_from_github_data(github_data)
 


### PR DESCRIPTION
If a user changes there name/login/email on github the data is not replicated to travis.

These commits allow data to be replicated on every travis login and the users github_id is used as a login identifier instead of the login name.
