### PR TITLE
Running rake db:fixtures:load doesn't load the data required to pass the Jasmine tests

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -111,7 +111,7 @@ h2. Running the tests
 Integration tests are implemented using "Jasmine":http://pivotal.github.com/jasmine and can be run in the browser:
 
 <pre>
-$ RAILS_ENV=jasmine rake db:migrate db:fixtures:load
+$ RAILS_ENV=jasmine rake db:migrate db:seed
 $ rails s thin -e jasmine
 $ open http://localhost:3000
 </pre>


### PR DESCRIPTION
Running rake db:fixtures:load doesn't load the data required to pass the Jasmine fixture integration tests. This data appears to be in the seeds file, which (as far as I can tell) doesn't get loaded when the fixtures are loaded.
