### PR TITLE
Possible fix for typeahead search #84

### DIFF
--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -54,7 +54,7 @@ $(document).ready(function() {
     });
   }
 
-  $('#search input').keyup(function(e) {
+  $('#search input').keyup(_.debounce(function(e) {
     var searchString = $(this).val();
 
     $.ajax({
@@ -65,7 +65,7 @@ $(document).ready(function() {
         Travis.app.repositories.refresh(repositories);
       }
     });
-  });
+  }, 100));
 });
 
 if (window.console) {
@@ -103,3 +103,5 @@ $.ajaxSetup({ cache: false });
 //   });
 // });
 //
+
+


### PR DESCRIPTION
Fix for typeahead search. If subsequent requests are not cancelled, they add a load for server when person is typing. It's almost unnoticable in development mode, but in production it creates amazingly big load, that could be avoided otherwise.
