### PR TITLE
switched 'rake' to 'bundle exec rake'

### DIFF
--- a/lib/travis/builder/base.rb
+++ b/lib/travis/builder/base.rb
@@ -18,7 +18,7 @@ module Travis
 
       def buildable
         @buildable ||= Travis::Buildable.new(
-          :script => 'rake',
+          :script => 'bundle exec rake',
           :commit => build['commit'],
           :config => build['config'],
           :url    => repository['url'] || "https://github.com/#{repository['slug']}"


### PR DESCRIPTION
Not sure if this is wanted but thought it would make more sense, given that rake 0.9.0 has come out and some applications see this error (e.g. http://travis-ci.org/#!/isotope11/xrono):

```
$ rake
rake aborted!
You have already activated rake 0.9.0, but your Gemfile requires rake 0.8.7. Consider using bundle exec.
```
