### PR TITLE
Script should be `bundle exec rake` when using Bundler

### DIFF
--- a/lib/travis/buildable.rb
+++ b/lib/travis/buildable.rb
@@ -22,7 +22,7 @@ module Travis
     def initialize(options = {})
       @url    = options[:url] || ''
       @commit = options[:commit]
-      @script = options[:script]
+      @script = options[:script] || script_command
       @config = Config.new(options[:config]) unless options[:config].blank?
       @path   = extract_path(url)
     end
@@ -80,6 +80,10 @@ module Travis
         command = [(env + [command]).join(' ')]
         command.unshift("rvm use #{config['rvm']}") if config['rvm']
         command
+      end
+
+      def script_command
+         File.exists?(config.gemfile) ? 'bundle exec rake' : 'rake'
       end
 
       def env

--- a/lib/travis/builder/base.rb
+++ b/lib/travis/builder/base.rb
@@ -18,7 +18,6 @@ module Travis
 
       def buildable
         @buildable ||= Travis::Buildable.new(
-          :script => 'rake',
           :commit => build['commit'],
           :config => build['config'],
           :url    => repository['url'] || "https://github.com/#{repository['slug']}"


### PR DESCRIPTION
If there is a Gemfile, use `bundle exec rake` instead of just plain `rake`. If there isn't a Gemfile, fallback and simply use `rake`.
