### PR TITLE
Travis builds gh-pages branch

### DIFF
--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -39,7 +39,7 @@ class Build < ActiveRecord::Base
     end
 
     def exclude?(attributes)
-      attributes.key?(:branch) && attributes[:branch].match(/gh_pages/i)
+      attributes.key?(:branch) && attributes[:branch].match(/gh[-_]pages/i)
     end
   end
 

--- a/test/integration/builds_controller_test.rb
+++ b/test/integration/builds_controller_test.rb
@@ -37,6 +37,7 @@ class BuildsControllerTest < ActionDispatch::IntegrationTest
   test 'POST to /builds (ping from github) does not create a build record when the branch is gh_pages' do
     assert_no_difference('Build.count') do
       post '/builds', { :payload => GITHUB_PAYLOADS['gh-pages-update'] }, 'HTTP_AUTHORIZATION' => credentials
+      post '/builds', { :payload => GITHUB_PAYLOADS['gh_pages-update'] }, 'HTTP_AUTHORIZATION' => credentials
     end
   end
 

--- a/test/test_helpers/payloads.rb
+++ b/test/test_helpers/payloads.rb
@@ -71,6 +71,30 @@ GITHUB_PAYLOADS = {
         "email": "chris@flooose.de"
       }
     }],
+    "ref": "refs/heads/gh-pages"
+  }),
+  "gh_pages-update" => %({
+    "repository": {
+      "url": "http://github.com/svenfuchs/gem-release",
+      "name": "gem-release",
+      "owner": {
+        "email": "svenfuchs@artweb-design.de",
+        "name": "svenfuchs"
+      }
+    },
+    "commits": [{
+      "id":        "9854592",
+      "message":   "Bump to 0.0.15",
+      "timestamp": "2010-10-27 04:32:37",
+      "committer": {
+        "name":  "Sven Fuchs",
+        "email": "svenfuchs@artweb-design.de"
+      },
+      "author": {
+        "name":  "Christopher Floess",
+        "email": "chris@flooose.de"
+      }
+    }],
     "ref": "refs/heads/gh_pages"
   }),
 


### PR DESCRIPTION
Travis currently ignores the `gh_pages` branch of a project. But GitHub also allows to use `gh-pages` for pages.

This fails of course: http://travis-ci.org/koraktor/metior/builds/22597

The attached patch fixes builds to also skip the branch if it's named with a dash instead of an underscore.
