### PR TITLE
Fixed child build order for matrix builds

### DIFF
--- a/public/javascripts/app/models/build.js
+++ b/public/javascripts/app/models/build.js
@@ -131,9 +131,9 @@ Travis.Collections.Builds = Travis.Collections.Base.extend({
   },
   comparator: function(build) {
     // this sorts matrix child builds below their child builds, i.e. the actual order will be like: 4, 3, 3.1, 3.2, 3.3., 2, 1
-    var number = parseInt(build.get('number'));
-    var fraction = parseFloat(build.get('number')) - number;
-    return number - fraction;
+    var number = String(build.get('number'));
+    var fraction = parseInt(number.substr(number.indexOf('.') + 1));
+    return parseInt(number) * 1000000 - fraction;
   }
 });
 

--- a/public/javascripts/tests/fixtures/models/builds/3.json
+++ b/public/javascripts/tests/fixtures/models/builds/3.json
@@ -1,1 +1,199 @@
-{"number":"3","committed_at":"2010-11-12T12:58:00Z","commit":"add057e66c3e1d59ef1f","config":{"gemfile":["test/Gemfile.rails-2.3.x","test/Gemfile.rails-3.0.x"],"rvm":["1.8.7","1.9.2"]},"committer_name":"Sven Fuchs","matrix":[{"committed_at":"2010-11-12T12:58:00Z","number":"3.1","commit":"add057e66c3e1d59ef1f","committer_name":"Sven Fuchs","config":{"gemfile":"test/Gemfile.rails-2.3.x","rvm":"1.8.7"},"branch":"master","log":"","id":4,"parent_id":3,"started_at":"2010-11-12T13:00:00Z","committer_email":"svenfuchs@artweb-design.de","message":"unignore Gemfile.lock","repository_id":1},{"committed_at":"2010-11-12T12:58:00Z","number":"3.2","commit":"add057e66c3e1d59ef1f","committer_name":"Sven Fuchs","config":{"gemfile":"test/Gemfile.rails-3.0.x","rvm":"1.8.7"},"branch":"master","log":"","id":5,"parent_id":3,"started_at":"2010-11-12T13:00:00Z","committer_email":"svenfuchs@artweb-design.de","message":"unignore Gemfile.lock","repository_id":1},{"committed_at":"2010-11-12T12:58:00Z","number":"3.3","commit":"add057e66c3e1d59ef1f","committer_name":"Sven Fuchs","config":{"gemfile":"test/Gemfile.rails-2.3.x","rvm":"1.9.2"},"branch":"master","log":"","id":6,"parent_id":3,"started_at":"2010-11-12T13:00:00Z","committer_email":"svenfuchs@artweb-design.de","message":"unignore Gemfile.lock","repository_id":1},{"committed_at":"2010-11-12T12:58:00Z","number":"3.4","commit":"add057e66c3e1d59ef1f","committer_name":"Sven Fuchs","config":{"gemfile":"test/Gemfile.rails-3.0.x","rvm":"1.9.2"},"branch":"master","log":"","id":7,"parent_id":3,"started_at":"2010-11-12T13:00:00Z","committer_email":"svenfuchs@artweb-design.de","message":"unignore Gemfile.lock","repository_id":1}],"log":"minimal build 3 log ...","branch":"master","id":3,"started_at":"2010-11-12T13:00:00Z","repository_id":1,"message":"unignore Gemfile.lock","committer_email":"svenfuchs@artweb-design.de"}
+{
+  "number": "3",
+  "committed_at": "2010-11-12T12:58:00Z",
+  "commit": "add057e66c3e1d59ef1f",
+  "config": {
+    "gemfile": ["test/Gemfile.rails-2.3.x", "test/Gemfile.rails-3.0.x"],
+    "rvm": ["1.8.7", "1.9.2", "jruby", "rbx", "ree"]
+  },
+  "committer_name": "Sven Fuchs",
+  "matrix": [
+    {
+      "committed_at": "2010-11-12T12:58:00Z",
+      "number": "3.1",
+      "commit": "add057e66c3e1d59ef1f",
+      "committer_name": "Sven Fuchs",
+      "config": {
+        "gemfile": "test/Gemfile.rails-2.3.x",
+        "rvm": "1.8.7"
+      },
+      "branch": "master",
+      "log": "",
+      "id": 4,
+      "parent_id": 3,
+      "started_at": "2010-11-12T13:00:00Z",
+      "committer_email": "svenfuchs@artweb-design.de",
+      "message": "unignore Gemfile.lock",
+      "repository_id":1
+    },
+    {
+      "committed_at": "2010-11-12T12:58:00Z",
+      "number": "3.2",
+      "commit": "add057e66c3e1d59ef1f",
+      "committer_name": "Sven Fuchs",
+      "config": {
+        "gemfile": "test/Gemfile.rails-3.0.x",
+        "rvm": "1.8.7"
+      },
+      "branch": "master",
+      "log": "",
+      "id": 5,
+      "parent_id": 3,
+      "started_at": "2010-11-12T13:00:00Z",
+      "committer_email": "svenfuchs@artweb-design.de",
+      "message": "unignore Gemfile.lock",
+      "repository_id":1
+    },
+    {
+      "committed_at": "2010-11-12T12:58:00Z",
+      "number": "3.3",
+      "commit": "add057e66c3e1d59ef1f",
+      "committer_name": "Sven Fuchs",
+      "config": {
+        "gemfile": "test/Gemfile.rails-2.3.x",
+        "rvm": "1.9.2"
+      },
+      "branch": "master",
+      "log": "",
+      "id": 6,
+      "parent_id": 3,
+      "started_at": "2010-11-12T13:00:00Z",
+      "committer_email": "svenfuchs@artweb-design.de",
+      "message": "unignore Gemfile.lock",
+      "repository_id":1
+    },
+    {
+      "committed_at": "2010-11-12T12:58:00Z",
+      "number": "3.4",
+      "commit": "add057e66c3e1d59ef1f",
+      "committer_name": "Sven Fuchs",
+      "config": {
+        "gemfile": "test/Gemfile.rails-3.0.x",
+        "rvm": "1.9.2"
+      },
+      "branch": "master",
+      "log": "",
+      "id": 7,
+      "parent_id": 3,
+      "started_at": "2010-11-12T13:00:00Z",
+      "committer_email": "svenfuchs@artweb-design.de",
+      "message": "unignore Gemfile.lock",
+      "repository_id":1
+    },
+    {
+      "committed_at": "2010-11-12T12:58:00Z",
+      "number": "3.5",
+      "commit": "add057e66c3e1d59ef1f",
+      "committer_name": "Sven Fuchs",
+      "config": {
+        "gemfile": "test/Gemfile.rails-2.3.x",
+        "rvm": "jruby"
+      },
+      "branch": "master",
+      "log": "",
+      "id": 6,
+      "parent_id": 3,
+      "started_at": "2010-11-12T13:00:00Z",
+      "committer_email": "svenfuchs@artweb-design.de",
+      "message": "unignore Gemfile.lock",
+      "repository_id":1
+    },
+    {
+      "committed_at": "2010-11-12T12:58:00Z",
+      "number": "3.6",
+      "commit": "add057e66c3e1d59ef1f",
+      "committer_name": "Sven Fuchs",
+      "config": {
+        "gemfile": "test/Gemfile.rails-3.0.x",
+        "rvm": "jruby"
+      },
+      "branch": "master",
+      "log": "",
+      "id": 7,
+      "parent_id": 3,
+      "started_at": "2010-11-12T13:00:00Z",
+      "committer_email": "svenfuchs@artweb-design.de",
+      "message": "unignore Gemfile.lock",
+      "repository_id":1
+    },
+    {
+      "committed_at": "2010-11-12T12:58:00Z",
+      "number": "3.7",
+      "commit": "add057e66c3e1d59ef1f",
+      "committer_name": "Sven Fuchs",
+      "config": {
+        "gemfile": "test/Gemfile.rails-2.3.x",
+        "rvm": "rbx"
+      },
+      "branch": "master",
+      "log": "",
+      "id": 6,
+      "parent_id": 3,
+      "started_at": "2010-11-12T13:00:00Z",
+      "committer_email": "svenfuchs@artweb-design.de",
+      "message": "unignore Gemfile.lock",
+      "repository_id":1
+    },
+    {
+      "committed_at": "2010-11-12T12:58:00Z",
+      "number": "3.8",
+      "commit": "add057e66c3e1d59ef1f",
+      "committer_name": "Sven Fuchs",
+      "config": {
+        "gemfile": "test/Gemfile.rails-3.0.x",
+        "rvm": "rbx"
+      },
+      "branch": "master",
+      "log": "",
+      "id": 7,
+      "parent_id": 3,
+      "started_at": "2010-11-12T13:00:00Z",
+      "committer_email": "svenfuchs@artweb-design.de",
+      "message": "unignore Gemfile.lock",
+      "repository_id":1
+    },
+    {
+      "committed_at": "2010-11-12T12:58:00Z",
+      "number": "3.9",
+      "commit": "add057e66c3e1d59ef1f",
+      "committer_name": "Sven Fuchs",
+      "config": {
+        "gemfile": "test/Gemfile.rails-2.3.x",
+        "rvm": "ree"
+      },
+      "branch": "master",
+      "log": "",
+      "id": 6,
+      "parent_id": 3,
+      "started_at": "2010-11-12T13:00:00Z",
+      "committer_email": "svenfuchs@artweb-design.de",
+      "message": "unignore Gemfile.lock",
+      "repository_id":1
+    },
+    {
+      "committed_at": "2010-11-12T12:58:00Z",
+      "number": "3.10",
+      "commit": "add057e66c3e1d59ef1f",
+      "committer_name": "Sven Fuchs",
+      "config": {
+        "gemfile": "test/Gemfile.rails-3.0.x",
+        "rvm": "ree"
+      },
+      "branch": "master",
+      "log": "",
+      "id": 7,
+      "parent_id": 3,
+      "started_at": "2010-11-12T13:00:00Z",
+      "committer_email": "svenfuchs@artweb-design.de",
+      "message": "unignore Gemfile.lock",
+      "repository_id":1
+    }
+  ],
+  "log": "minimal build 3 log ...",
+  "branch": "master",
+  "id": 3,
+  "started_at": "2010-11-12T13:00:00Z",
+  "repository_id": 1,
+  "message": "unignore Gemfile.lock",
+  "committer_email": "svenfuchs@artweb-design.de"
+}

--- a/public/javascripts/tests/fixtures/models/repositories/1/builds.json
+++ b/public/javascripts/tests/fixtures/models/repositories/1/builds.json
@@ -1,1 +1,231 @@
-[{"number":"3","committed_at":"2010-11-12T12:58:00Z","commit":"add057e66c3e1d59ef1f","config":{"gemfile":["test/Gemfile.rails-2.3.x","test/Gemfile.rails-3.0.x"],"rvm":["1.8.7","1.9.2"]},"committer_name":"Sven Fuchs","matrix":[{"committed_at":"2010-11-12T12:58:00Z","number":"3.1","commit":"add057e66c3e1d59ef1f","committer_name":"Sven Fuchs","config":{"gemfile":"test/Gemfile.rails-2.3.x","rvm":"1.8.7"},"branch":"master","log":"","id":4,"parent_id":3,"started_at":"2010-11-12T13:00:00Z","committer_email":"svenfuchs@artweb-design.de","message":"unignore Gemfile.lock","repository_id":1},{"committed_at":"2010-11-12T12:58:00Z","number":"3.2","commit":"add057e66c3e1d59ef1f","committer_name":"Sven Fuchs","config":{"gemfile":"test/Gemfile.rails-3.0.x","rvm":"1.8.7"},"branch":"master","log":"","id":5,"parent_id":3,"started_at":"2010-11-12T13:00:00Z","committer_email":"svenfuchs@artweb-design.de","message":"unignore Gemfile.lock","repository_id":1},{"committed_at":"2010-11-12T12:58:00Z","number":"3.3","commit":"add057e66c3e1d59ef1f","committer_name":"Sven Fuchs","config":{"gemfile":"test/Gemfile.rails-2.3.x","rvm":"1.9.2"},"branch":"master","log":"","id":6,"parent_id":3,"started_at":"2010-11-12T13:00:00Z","committer_email":"svenfuchs@artweb-design.de","message":"unignore Gemfile.lock","repository_id":1},{"committed_at":"2010-11-12T12:58:00Z","number":"3.4","commit":"add057e66c3e1d59ef1f","committer_name":"Sven Fuchs","config":{"gemfile":"test/Gemfile.rails-3.0.x","rvm":"1.9.2"},"branch":"master","log":"","id":7,"parent_id":3,"started_at":"2010-11-12T13:00:00Z","committer_email":"svenfuchs@artweb-design.de","message":"unignore Gemfile.lock","repository_id":1}],"log":"minimal build 3 log ...","branch":"master","id":3,"started_at":"2010-11-12T13:00:00Z","repository_id":1,"message":"unignore Gemfile.lock","committer_email":"svenfuchs@artweb-design.de"},{"number":"2","committed_at":"2010-11-12T12:28:00Z","commit":"91d1b7b2a310131fe3f8","finished_at":"2010-11-12T12:30:08Z","committer_name":"Sven Fuchs","log":"minimal build 2 log ...","branch":"master","id":2,"started_at":"2010-11-12T12:30:00Z","status":0,"repository_id":1,"message":"Bump to 0.0.22","committer_email":"svenfuchs@artweb-design.de"},{"number":"1","committed_at":"2010-11-12T11:58:00Z","commit":"1a738d9d6f297c105ae2","finished_at":"2010-11-12T12:00:08Z","committer_name":"Sven Fuchs","log":"minimal build 1 log ...","branch":"master","id":1,"started_at":"2010-11-12T12:00:00Z","status":1,"repository_id":1,"message":"add Gemfile","committer_email":"svenfuchs@artweb-design.de"}]
+[
+  {
+    "number": "3",
+    "committed_at": "2010-11-12T12:58:00Z",
+    "commit": "add057e66c3e1d59ef1f",
+    "config": {
+      "gemfile": ["test/Gemfile.rails-2.3.x", "test/Gemfile.rails-3.0.x"],
+      "rvm": ["1.8.7", "1.9.2", "jruby", "rbx", "ree"]
+    },
+    "committer_name": "Sven Fuchs",
+    "matrix": [
+      {
+        "committed_at": "2010-11-12T12:58:00Z",
+        "number": "3.1",
+        "commit": "add057e66c3e1d59ef1f",
+        "committer_name": "Sven Fuchs",
+        "config": {
+          "gemfile": "test/Gemfile.rails-2.3.x",
+          "rvm": "1.8.7"
+        },
+        "branch": "master",
+        "log": "",
+        "id": 4,
+        "parent_id": 3,
+        "started_at": "2010-11-12T13:00:00Z",
+        "committer_email": "svenfuchs@artweb-design.de",
+        "message": "unignore Gemfile.lock",
+        "repository_id":1
+      },
+      {
+        "committed_at": "2010-11-12T12:58:00Z",
+        "number": "3.2",
+        "commit": "add057e66c3e1d59ef1f",
+        "committer_name": "Sven Fuchs",
+        "config": {
+          "gemfile": "test/Gemfile.rails-3.0.x",
+          "rvm": "1.8.7"
+        },
+        "branch": "master",
+        "log": "",
+        "id": 5,
+        "parent_id": 3,
+        "started_at": "2010-11-12T13:00:00Z",
+        "committer_email": "svenfuchs@artweb-design.de",
+        "message": "unignore Gemfile.lock",
+        "repository_id":1
+      },
+      {
+        "committed_at": "2010-11-12T12:58:00Z",
+        "number": "3.3",
+        "commit": "add057e66c3e1d59ef1f",
+        "committer_name": "Sven Fuchs",
+        "config": {
+          "gemfile": "test/Gemfile.rails-2.3.x",
+          "rvm": "1.9.2"
+        },
+        "branch": "master",
+        "log": "",
+        "id": 6,
+        "parent_id": 3,
+        "started_at": "2010-11-12T13:00:00Z",
+        "committer_email": "svenfuchs@artweb-design.de",
+        "message": "unignore Gemfile.lock",
+        "repository_id":1
+      },
+      {
+        "committed_at": "2010-11-12T12:58:00Z",
+        "number": "3.4",
+        "commit": "add057e66c3e1d59ef1f",
+        "committer_name": "Sven Fuchs",
+        "config": {
+          "gemfile": "test/Gemfile.rails-3.0.x",
+          "rvm": "1.9.2"
+        },
+        "branch": "master",
+        "log": "",
+        "id": 7,
+        "parent_id": 3,
+        "started_at": "2010-11-12T13:00:00Z",
+        "committer_email": "svenfuchs@artweb-design.de",
+        "message": "unignore Gemfile.lock",
+        "repository_id":1
+      },
+      {
+        "committed_at": "2010-11-12T12:58:00Z",
+        "number": "3.5",
+        "commit": "add057e66c3e1d59ef1f",
+        "committer_name": "Sven Fuchs",
+        "config": {
+          "gemfile": "test/Gemfile.rails-2.3.x",
+          "rvm": "jruby"
+        },
+        "branch": "master",
+        "log": "",
+        "id": 6,
+        "parent_id": 3,
+        "started_at": "2010-11-12T13:00:00Z",
+        "committer_email": "svenfuchs@artweb-design.de",
+        "message": "unignore Gemfile.lock",
+        "repository_id":1
+      },
+      {
+        "committed_at": "2010-11-12T12:58:00Z",
+        "number": "3.6",
+        "commit": "add057e66c3e1d59ef1f",
+        "committer_name": "Sven Fuchs",
+        "config": {
+          "gemfile": "test/Gemfile.rails-3.0.x",
+          "rvm": "jruby"
+        },
+        "branch": "master",
+        "log": "",
+        "id": 7,
+        "parent_id": 3,
+        "started_at": "2010-11-12T13:00:00Z",
+        "committer_email": "svenfuchs@artweb-design.de",
+        "message": "unignore Gemfile.lock",
+        "repository_id":1
+      },
+      {
+        "committed_at": "2010-11-12T12:58:00Z",
+        "number": "3.7",
+        "commit": "add057e66c3e1d59ef1f",
+        "committer_name": "Sven Fuchs",
+        "config": {
+          "gemfile": "test/Gemfile.rails-2.3.x",
+          "rvm": "rbx"
+        },
+        "branch": "master",
+        "log": "",
+        "id": 6,
+        "parent_id": 3,
+        "started_at": "2010-11-12T13:00:00Z",
+        "committer_email": "svenfuchs@artweb-design.de",
+        "message": "unignore Gemfile.lock",
+        "repository_id":1
+      },
+      {
+        "committed_at": "2010-11-12T12:58:00Z",
+        "number": "3.8",
+        "commit": "add057e66c3e1d59ef1f",
+        "committer_name": "Sven Fuchs",
+        "config": {
+          "gemfile": "test/Gemfile.rails-3.0.x",
+          "rvm": "rbx"
+        },
+        "branch": "master",
+        "log": "",
+        "id": 7,
+        "parent_id": 3,
+        "started_at": "2010-11-12T13:00:00Z",
+        "committer_email": "svenfuchs@artweb-design.de",
+        "message": "unignore Gemfile.lock",
+        "repository_id":1
+      },
+      {
+        "committed_at": "2010-11-12T12:58:00Z",
+        "number": "3.9",
+        "commit": "add057e66c3e1d59ef1f",
+        "committer_name": "Sven Fuchs",
+        "config": {
+          "gemfile": "test/Gemfile.rails-2.3.x",
+          "rvm": "ree"
+        },
+        "branch": "master",
+        "log": "",
+        "id": 6,
+        "parent_id": 3,
+        "started_at": "2010-11-12T13:00:00Z",
+        "committer_email": "svenfuchs@artweb-design.de",
+        "message": "unignore Gemfile.lock",
+        "repository_id":1
+      },
+      {
+        "committed_at": "2010-11-12T12:58:00Z",
+        "number": "3.10",
+        "commit": "add057e66c3e1d59ef1f",
+        "committer_name": "Sven Fuchs",
+        "config": {
+          "gemfile": "test/Gemfile.rails-3.0.x",
+          "rvm": "ree"
+        },
+        "branch": "master",
+        "log": "",
+        "id": 7,
+        "parent_id": 3,
+        "started_at": "2010-11-12T13:00:00Z",
+        "committer_email": "svenfuchs@artweb-design.de",
+        "message": "unignore Gemfile.lock",
+        "repository_id":1
+      }
+    ],
+    "log": "minimal build 3 log...",
+    "branch": "master",
+    "id": 3,
+    "started_at": "2010-11-12T13:00:00Z",
+    "repository_id": 1,
+    "message": "unignore Gemfile.lock",
+    "committer_email": "svenfuchs@artweb-design.de"
+  },
+  {
+    "number": "2",
+    "committed_at": "2010-11-12T12:28:00Z",
+    "commit": "91d1b7b2a310131fe3f8",
+    "finished_at": "2010-11-12T12:30:08Z",
+    "committer_name": "Sven Fuchs",
+    "log": "minimal build 2 log ...",
+    "branch": "master",
+    "id": 2,
+    "started_at": "2010-11-12T12:30:00Z",
+    "status": 0,
+    "repository_id": 1,
+    "message": "Bump to 0.0.22",
+    "committer_email": "svenfuchs@artweb-design.de"
+  },
+  {
+    "number": "1",
+    "committed_at": "2010-11-12T11:58:00Z",
+    "commit": "1a738d9d6f297c105ae2",
+    "finished_at": "2010-11-12T12:00:08Z",
+    "committer_name": "Sven Fuchs",
+    "log": "minimal build 1 log...",
+    "branch": "master",
+    "id": 1,
+    "started_at": "2010-11-12T12:00:00Z",
+    "status": 1,
+    "repository_id": 1,
+    "message": "add Gemfile",
+    "committer_email": "svenfuchs@artweb-design.de"
+  }
+]

--- a/public/javascripts/tests/integration/events_test.js
+++ b/public/javascripts/tests/integration/events_test.js
@@ -316,8 +316,8 @@ describe('Events:', function() {
         });
 
         it('does not remove the sibling builds from the matrix table', function() {
-          expect(Travis.app.repositories.get(1).builds.get(3).matrix.length).toEqual(4)
-          expect($('#tab_build #matrix tbody tr').length).toEqual(4);
+          expect(Travis.app.repositories.get(1).builds.get(3).matrix.length).toEqual(10)
+          expect($('#tab_build #matrix tbody tr').length).toEqual(10);
         });
       });
 
@@ -343,6 +343,12 @@ describe('Events:', function() {
             ['3.2',   'test/Gemfile.rails-3.0.x', '1.8.7'],
             ['3.3',   'test/Gemfile.rails-2.3.x', '1.9.2'],
             ['3.4',   'test/Gemfile.rails-3.0.x', '1.9.2'],
+            ['3.5',   'test/Gemfile.rails-2.3.x', 'jruby'],
+            ['3.6',   'test/Gemfile.rails-3.0.x', 'jruby'],
+            ['3.7',   'test/Gemfile.rails-2.3.x', 'rbx'],
+            ['3.8',   'test/Gemfile.rails-3.0.x', 'rbx'],
+            ['3.9',   'test/Gemfile.rails-2.3.x', 'ree'],
+            ['3.10',  'test/Gemfile.rails-3.0.x', 'ree']
           ]);
           expect($('#tab_build #matrix tbody tr:nth-child(1)').hasClass('green')).toBeTruthy();
           expect($('#tab_build #matrix tbody tr:nth-child(2)').hasClass('green')).toBeFalsy();

--- a/public/javascripts/tests/integration/pages_test.js
+++ b/public/javascripts/tests/integration/pages_test.js
@@ -4,6 +4,12 @@ var MATRIX = [
   ['3.2',   'test/Gemfile.rails-3.0.x', '1.8.7', '-',        '4 hrs 30 sec' ],
   ['3.3',   'test/Gemfile.rails-2.3.x', '1.9.2', '-',        '4 hrs 30 sec' ],
   ['3.4',   'test/Gemfile.rails-3.0.x', '1.9.2', '-',        '4 hrs 30 sec' ],
+  ['3.5',   'test/Gemfile.rails-2.3.x', 'jruby', '-',        '4 hrs 30 sec' ],
+  ['3.6',   'test/Gemfile.rails-3.0.x', 'jruby', '-',        '4 hrs 30 sec' ],
+  ['3.7',   'test/Gemfile.rails-2.3.x', 'rbx',   '-',        '4 hrs 30 sec' ],
+  ['3.8',   'test/Gemfile.rails-3.0.x', 'rbx',   '-',        '4 hrs 30 sec' ],
+  ['3.9',   'test/Gemfile.rails-2.3.x', 'ree',   '-',        '4 hrs 30 sec' ],
+  ['3.10',  'test/Gemfile.rails-3.0.x', 'ree',   '-',        '4 hrs 30 sec' ]
 ];
 
 var HISTORY = {

--- a/public/javascripts/tests/views/build/matrix_test.js
+++ b/public/javascripts/tests/views/build/matrix_test.js
@@ -14,6 +14,12 @@ describe('Views: the build matrix table view', function() {
       ['3.2',   'test/Gemfile.rails-3.0.x', '1.8.7' ],
       ['3.3',   'test/Gemfile.rails-2.3.x', '1.9.2' ],
       ['3.4',   'test/Gemfile.rails-3.0.x', '1.9.2' ],
+      ['3.5',   'test/Gemfile.rails-2.3.x', 'jruby' ],
+      ['3.6',   'test/Gemfile.rails-3.0.x', 'jruby' ],
+      ['3.7',   'test/Gemfile.rails-2.3.x', 'rbx' ],
+      ['3.8',   'test/Gemfile.rails-3.0.x', 'rbx' ],
+      ['3.9',   'test/Gemfile.rails-2.3.x', 'ree' ],
+      ['3.10',  'test/Gemfile.rails-3.0.x', 'ree' ]
     ]);
     expect(this.matrix.el.find('tbody .green')).toBeEmpty();
   });


### PR DESCRIPTION
Currently, matrix builds with 10 or more child builds won't be sorted correctly.
See ruby-amqp/amqp for a [sample](http://travis-ci.org/#!/ruby-amqp/amqp/builds/30087).

I fixed the `comparator` function of `Travis.Collections.Builds` to improve this (at least for builds with less than a million childs ;)). Backbone.js doesn't seem to provide a better comparing mechanism, so I think this is the best solution right now.
