### PR TITLE
Expose :owner_name/:name.xml to allow builds to be monitored

### DIFF
--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -14,6 +14,10 @@ class RepositoriesController < ApplicationController
         response.headers["Expires"] = CGI.rfc1123_date(Time.now)
         send_file(status_image_path, :type => 'image/png', :disposition => 'inline')
       end
+      format.xml do
+        response.headers["Expires"] = CGI.rfc1123_date(Time.now)
+        render :xml => Repository.xml_status_by(params.slice(:owner_name, :name))
+      end
     end
   end
 

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -35,6 +35,10 @@ class Repository < ActiveRecord::Base
       repository.last_finished_build.status == 0 ? 'stable' : 'unstable'
     end
 
+    def xml_status_by(attributes)
+      "<status>#{human_status_by(attributes)}</status>"
+    end
+
     def search(query)
       where("repositories.name LIKE ? OR repositories.owner_name LIKE ?", "%#{query}%", "%#{query}%")
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ TravisCi::Application.routes.draw do
   root :to => 'home#index'
 
   match ":owner_name/:name.png", :to => 'repositories#show', :format => 'png'
+  match ":owner_name/:name.xml", :to => 'repositories#show', :format => 'xml'
 
   devise_for :users, :controllers => { :omniauth_callbacks => "users/omniauth_callbacks" }
 

--- a/spec/controllers/repositories_controller_spec.rb
+++ b/spec/controllers/repositories_controller_spec.rb
@@ -87,5 +87,12 @@ describe RepositoriesController do
         with("#{Rails.public_path}/images/status/#{status}.png", { :type=>"image/png", :disposition=>"inline" }).
         once
     end
+
+    it "responds with XML" do
+      Factory(:successfull_build, :repository => repository)
+      post(:show, :format => "xml", :owner_name => "sven", :name => "fuchs")
+      response.headers['Content-Type'].should match('application/xml')
+    end
+
   end
 end


### PR DESCRIPTION
I've made a fairly simple change that exposes an XML response, similar to the PNG response. This allows me to use command line tools to monitor the current status of the repository. The entire build matrix should be exposed, however, I think this is simple enough to allow for rapid integration.

Example:

```
http://localhost:3000/josevalim/enginex.xml
```

Returns:

```
<status>unstable</status>
```
