### PR TITLE
Use devise 1.4.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'pg',                '~> 0.11.0'
 gem 'yajl-ruby',         '~> 0.8.2'
 
 gem 'compass',           '~> 0.11.3'
-gem 'devise',            '~> 1.4.0'
+gem 'devise',            '~> 1.4.2'
 gem 'oa-oauth',          '~> 0.3.0.rc1', :require => 'omniauth/oauth', :git => 'https://github.com/intridea/omniauth.git'
 
 gem 'refraction',        '~> 0.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,7 +90,7 @@ GEM
       sass (~> 3.1)
     crack (0.1.8)
     database_cleaner (0.6.7)
-    devise (1.4.0)
+    devise (1.4.2)
       bcrypt-ruby (~> 2.1.2)
       orm_adapter (~> 0.0.3)
       warden (~> 1.0.3)
@@ -268,7 +268,7 @@ DEPENDENCIES
   clockwork
   compass (~> 0.11.3)
   database_cleaner
-  devise (~> 1.4.0)
+  devise (~> 1.4.2)
   factory_girl (~> 1.3)
   factory_girl_rails
   fakeredis


### PR DESCRIPTION
I know the use of devise 1.4.1 has been reverted. But 1.4.0 is yanked and therefore can't be used anymore.
Therefore, this will upgrade devise to 1.4.2 and make the use of travis possible again :)
