### PR TITLE
Add the branch in the worker's arguments

### DIFF
--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -132,7 +132,7 @@ class Build < ActiveRecord::Base
 
   JSON_ATTRS = {
     :default            => all_attrs,
-    :job                => [:id, :number, :commit, :config],
+    :job                => [:id, :number, :commit, :config, :branch],
     :'build:queued'     => [:id, :number],
     :'build:started'    => all_attrs - [:status, :log, :finished_at],
     :'build:configured' => [:id, :parent_id, :number, :config],


### PR DESCRIPTION
This is needed in order to be able to filter builds based on the branch.
