### PR TITLE
basic Assets.io integration

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,7 +24,9 @@
         assets.force();
         assets.version(1);
         assets.css('/stylesheets/application.css /stylesheets/jquery.tipsy.css', { debug: true });
-        assets.js('/javascripts/travis.js /javascripts/templates.js', { debug: true });
+        assets.js('/javascripts/travis.js /javascripts/templates.js', { debug: true }, function () {
+          window.pusher = new Pusher('<%= Pusher.key -%>');
+        });
       </script>
 
     <% else %>
@@ -118,6 +120,6 @@
       <%= yield %>
     </div>
 
-    <%= javascript_tag "var pusher = new Pusher('#{Pusher.key}');" unless Rails.env.jasmine? %>
+    <%= javascript_tag "var pusher = new Pusher('#{Pusher.key}');" unless Rails.env.production? || Rails.env.jasmine? %>
   </body>
 </html>


### PR DESCRIPTION
This is how a basic Assets.io integration could look like. Could you try that on staging?

It builds on top of the Jammit asset packages and I think it would be good to keep it that way, because Jammit still gives you:
- asset package definitions in one place, namely assets.yml
- wildcard support for package sources
- integrated support for building the JS templates

**The one thing that has to be figured out** is how to determine the asset version! Do you already have any facility to get access to the the deployed git SHA, some global app version or anything like that?

If this is not the case, Jammit could be extended to provide a MD5 over the given asset packages.
