### PR TITLE
Upgrading fakeredis to 0.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ group :test do
   gem 'factory_girl_rails'
   gem 'mocha'
   gem 'test_declarative'
-  gem 'fakeredis'
+  gem 'fakeredis', '~> 0.2.0'
   gem 'webmock'
 
   platforms :ruby_18 do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,7 +89,8 @@ GEM
     factory_girl_rails (1.0.1)
       factory_girl (~> 1.3)
       railties (>= 3.0.0)
-    fakeredis (0.1.4)
+    fakeredis (0.2.0)
+      redis (~> 2.2.0)
     faraday (0.6.1)
       addressable (~> 2.2.4)
       multipart-post (~> 1.1.0)
@@ -268,7 +269,7 @@ DEPENDENCIES
   devise (~> 1.4.2)
   factory_girl (~> 1.3)
   factory_girl_rails
-  fakeredis
+  fakeredis (~> 0.2.0)
   hoptoad_notifier (~> 2.4.11)
   jammit (~> 0.6.0)
   jruby-openssl

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -26,7 +26,7 @@ class ActiveSupport::TestCase
     Mocha::Mockery.instance.verify
 
     Travis.pusher = TestHelpers::Mocks::Pusher.new
-    Resque.redis  = FakeRedis::Redis.new
+    Resque.redis  = Redis.new
 
     DatabaseCleaner.start
 


### PR DESCRIPTION
FakeRedis is now a Redis driver, it can be used with Redis gem without modifications
