### PR TITLE
Use SQLite for everything except production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ end
 
 group :development, :test do
   gem 'rspec-rails', '~> 2.6.1'
+  gem 'sqlite3'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,6 +231,7 @@ GEM
     sinatra (1.2.6)
       rack (~> 1.1)
       tilt (< 2.0, >= 1.2.2)
+    sqlite3 (1.3.4)
     test_declarative (0.0.5)
     thor (0.14.6)
     tilt (1.3.2)
@@ -292,6 +293,7 @@ DEPENDENCIES
   ruby-debug
   ruby-debug19
   silent-postgres (~> 0.0.8)
+  sqlite3
   test_declarative
   unicorn (~> 4.0.0)
   unobtrusive_flash (~> 0.0.2)

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,26 +1,24 @@
-defaults: &defaults
+production:
   adapter: postgresql
+  database: travis_production
   encoding: unicode
   pool: 5
-
-  # Minimum log levels, in increasing order:
-  #   debug5, debug4, debug3, debug2, debug1,
-  #   log, notice, warning, error, fatal, and panic
-  # The server defaults to notice.
   min_messages: warning
 
 development:
-  <<: *defaults
-  database: travis_development
-
-production:
-  <<: *defaults
-  database: travis_production
+  adapter: sqlite3
+  database: db/development.sqlite3
+  pool: 5
+  timeout: 5000
 
 jasmine:
-  <<: *defaults
-  database: travis_jasmine
+  adapter: sqlite3
+  database: db/jasmine.sqlite3
+  pool: 5
+  timeout: 5000
 
 test:
-  <<: *defaults
-  database: travis_test
+  adapter: sqlite3
+  database: db/test.sqlite3
+  pool: 5
+  timeout: 5000


### PR DESCRIPTION
This makes it easier to start developing on Travis, as you no longer have to install PostgreSQL first.

Unless some specific Postgres-trickery is needed, it should be okay.
