### PR TITLE
Escape commit message newlines in build emails

### DIFF
--- a/app/views/build_mailer/finished_email.html.erb
+++ b/app/views/build_mailer/finished_email.html.erb
@@ -5,7 +5,7 @@ Build : #<%= @build.number %><br>
 Duration : <%= build_duration(@build.started_at, @build.finished_at) %><br>
 Commit : <%= @commit.commit[0..7] %> (<%= @commit.branch %>)<br>
 Author : <%= @commit.author_name %><br>
-Message : <%= @commit.message %><br>
+Message : <%= h(@commit.message).gsub("\n", "<br>").html_safe %><br>
 <br>
 Status : <%= @build.status_message %><br>
 <br>

--- a/spec/mailers/build_mailer_spec.rb
+++ b/spec/mailers/build_mailer_spec.rb
@@ -30,6 +30,13 @@ describe BuildMailer do
       it 'is a multipart email' do
         mail.should be_multipart
       end
+
+      context 'in HTML' do
+        it 'escapes newlines in the commit message' do
+          build.commit.message = "bar\nbaz"
+          mail.body.encoded.should include("bar<br>baz")
+        end
+      end
     end
 
     describe 'for a broken build' do


### PR DESCRIPTION
Travis build emails in HTML format do not escape newlines in commit messages. This means commit messages effectively render any number of newlines as spaces. This can be awkward if commit messages have, say, paragraph breaks. This changes newline characters into <br> characters, while escaping everything else that needs to be escaped for the HTML in the email to be safe. This pull request also includes a spec to make sure that newlines in commit messages are changed into <br> tags in HTML build emails.
