### PR TITLE
Support alternatives to Hoptoad

### DIFF
--- a/config/initializers/hoptoad.rb
+++ b/config/initializers/hoptoad.rb
@@ -2,6 +2,14 @@ require 'travis'
 
 if Travis.config.hoptoad?
   HoptoadNotifier.configure do |config|
-    config.api_key = Travis.config.hoptoad.key
+    hoptoad = Travis.config.hoptoad
+
+    config.api_key = hoptoad.key
+    config.host = hoptoad.host if hoptoad.host
+    if config.port
+      config.port = hoptoad.port
+      config.secure = config.port == 443
+    end
   end
 end
+


### PR DESCRIPTION
Configure alternative host and port for HoptoadNotifier. For example, if you wanted to use [Errbit](https://github.com/errbit/errbit/) instead.
