### PR TITLE
Nicer default formatting for RSpec tests. (colorized output & documentation style)

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,4 @@
+--colour
+--tty
+--drb
+--format documentation


### PR DESCRIPTION
Makes this:

```
....................

Finished in 25.09 seconds
20 examples, 0 failures
```

look like this:

```
Build notifications ActiveSupport::TestCase
  send_email_notifications?
    returns true by default
    returns false if the build does not have any recipients
    returns false if the build has notifications disabled (deprecated api) (disabled => true)
    returns false if the build has notifications disabled (deprecated api) (disable => true)
    returns false if the build has notifications disabled
    returns true if build status is broken and previous build status is successful
    returns true if build status is successful and previous build status is broken
    returns false if both build status and previous build status is successful
    returns false if both build status and previous build status is broken
    verbose notifications
      returns true if both build status and previous build status is successful
      returns true if both build status and previous build status is broken
  email_recipients
    contains the author emails if the build has them set
    contains the committer emails if the build has them set
    contains the build's repository owner_email if it has one
    contains the owner details if it has a configuration but no emails specified
    equals the recipients specified in the build configuration if any
  send_webhook_notifications?
    returns true if the build configuration specifies webhooks
    returns false if the build configuration does not specify any webhooks
  webhooks
    returns an array of values if the build configuration specifies a single, comma separated string
    returns an array of values if the build configuration specifies an array of values

Finished in 24.94 seconds
20 examples, 0 failures
```
