### PR TITLE
When I added the builder_spec I noticed an inconsistency between Travis::Renderer and the way that the Rabl responder works. Therefore, this commit includes a change to the Travis::Renderer to address that potential issue.

### DIFF
--- a/lib/travis/renderer.rb
+++ b/lib/travis/renderer.rb
@@ -60,14 +60,19 @@ module Travis
 
       def model_name
         @model_name = begin
-          item = object.is_a?(Array) ? object.first : object
+          item = collection? ? object.first : object
           name = item.class.name.underscore
-          object.is_a?(Array) ? name.pluralize : name
+          collection? ? name.pluralize : name
         end
       end
 
       def raise_template_not_found
         raise "could not find rabl template for #{object.class.name} with #{options.inspect}"
       end
+      
+      def collection?
+        object.is_a?(Array) || (object.is_a?(ActiveRecord::Relation) && object.respond_to?(:slice))
+      end
+      
   end
 end

--- a/spec/controllers/builds_controller_spec.rb
+++ b/spec/controllers/builds_controller_spec.rb
@@ -1,11 +1,23 @@
 require 'spec_helper'
 
 describe BuildsController do
+  
+  before { Scenario.default }
+  
+  let(:repository) { Repository.first }
+  let(:builds) { repository.builds.recent }
+  
   describe 'GET :index' do
-    it 'returns a list of builds in json'
+    it 'returns a list of builds in json' do
+      get :index, :repository_id => repository.id, :format => :json
+      json_response.should == json_for_http(builds)
+    end
   end
 
   describe 'GET :show' do
-    it 'returns build details in json'
+    it 'returns build details in json' do
+      get :show, :repository_id => repository.id, :id => builds.first.id, :format => :json
+      json_response.should == json_for_http(builds.first)
+    end
   end
 end


### PR DESCRIPTION
Added builder spec and made Travis::Renderer consistent with Rabl rendering
