### PR TITLE
Fixed Jasmine specs

### DIFF
--- a/app/assets/javascripts/spec/helpers/build_spec.js
+++ b/app/assets/javascripts/spec/helpers/build_spec.js
@@ -70,8 +70,8 @@ describe('Helpers', function() {
         });
 
         it("returns a human readable time ago string if the build's finished time is known", function() {
-          spyOn($.timeago, 'now').andReturn(new Date('2011/01/01 05:00:00').getTime());
-          expect(view.get('finishedAt')).toEqual('about 3 hours ago'); // TODO hmmm, some timezone difference here. is that a problem?
+          spyOn($.timeago, 'now').andReturn(new Date(Date.UTC(2011, 0, 1, 4, 0, 0)).getTime());
+          expect(view.get('finishedAt')).toEqual('about 3 hours ago');
         });
       });
 

--- a/app/assets/javascripts/spec/models/repository_spec.js
+++ b/app/assets/javascripts/spec/models/repository_spec.js
@@ -96,7 +96,7 @@ describe('Travis.Repository', function() {
         });
 
         it("returns a human readable time ago string if the last build's finished time is known", function() {
-          spyOn($.timeago, 'now').andReturn(new Date('2011/01/01 05:00:00').getTime());
+          spyOn($.timeago, 'now').andReturn(new Date(Date.UTC(2011, 0, 1, 4, 0, 0)).getTime());
           expect(repository.get('formattedLastBuildFinishedAt')).toEqual('about 3 hours ago'); // TODO hmmm, some timezone difference here. is that a problem?
         });
       });

--- a/app/assets/javascripts/spec/views/builds/list_spec.js
+++ b/app/assets/javascripts/spec/views/builds/list_spec.js
@@ -4,7 +4,7 @@ describe('Views:', function() {
       var builds, view;
 
       beforeEach(function() {
-        spyOn($.timeago, 'now').andReturn(new Date('2011/01/01 05:00:00').getTime());
+        spyOn($.timeago, 'now').andReturn(new Date(Date.UTC(2011, 0, 1, 4, 0, 0)).getTime());
 
         builds = Test.Factory.Build.byRepository();
         view = createView('#main', { builds: builds, repositoryBinding: 'builds.repository', templateName: 'app/templates/builds/list' });

--- a/app/assets/javascripts/spec/views/builds/matrix_spec.js
+++ b/app/assets/javascripts/spec/views/builds/matrix_spec.js
@@ -4,7 +4,7 @@ describe('Views:', function() {
       var tabs, build, view;
 
       beforeEach(function() {
-        spyOn($.timeago, 'now').andReturn(new Date('2011/01/01 05:00:00').getTime());
+        spyOn($.timeago, 'now').andReturn(new Date(Date.UTC(2011, 0, 1, 4, 0, 0)).getTime());
 
         build = Test.Factory.Build.passing();
         view = createView('#main', {

--- a/app/assets/javascripts/spec/views/builds/show_spec.js
+++ b/app/assets/javascripts/spec/views/builds/show_spec.js
@@ -1,17 +1,21 @@
 describe('Views:', function() {
   describe('builds', function() {
+    var tabs, build, view;
+    
+    beforeEach(function() {
+      build = Test.Factory.Build.passing();
+    });
+    
     describe('show', function() {
-      var tabs, build, view;
-
+      
       beforeEach(function() {
-        build = Test.Factory.Build.passing();
         view = createView('#main', { repository: build.get('repository'), build: build, templateName: 'app/templates/builds/show' });
       });
-
+      
       afterEach(function() {
         view.destroy();
       });
-
+      
       it('shows the current build', function() {
         expect(view.$()).toShowBuildSummary(build);
       });
@@ -79,12 +83,21 @@ describe('Views:', function() {
           expect(view.$('#builds')).toExist();
         });
       });
-
-      describe('with a single-build matrix', function() {
-        it('renders the log', function() {
-          // spyOn(Travis.Log, 'filter').andCallFake(function(log) { return log; });
-          expect(view.$('pre.log')).toHaveText('1Done. Build script exited with: 0')
-        });
+    });
+    
+    describe('show with a single-build matrix', function() {
+      beforeEach(function() {
+        build = build.get('matrix').objectAt(0);
+        view = createView('#main', { repository: build.get('repository'), build: build, templateName: 'app/templates/builds/show' });
+      });
+      
+      afterEach(function() {
+        view.destroy();
+      });
+      
+      it('renders the log', function() {
+        // spyOn(Travis.Log, 'filter').andCallFake(function(log) { return log; });
+        expect(view.$('pre.log')).toHaveText('1Done. Build script exited with: 0')
       });
     });
   });


### PR DESCRIPTION
Use UTC dates in Jasmine specs (in stubs) so that they don't depend on timezone.
Fixed "show with a single-build matrix" spec (I'm not sure, If the names of specs here is good, but, as I see, now spec at least follows the current build-view logic).
