### PR TITLE
[ui] Make switching between Recent and Search tabs work

### DIFF
--- a/app/assets/javascripts/app.js
+++ b/app/assets/javascripts/app.js
@@ -69,6 +69,13 @@ var Travis = SC.Application.create({
     $('#top .profile').mouseout(function() { $('#top .profile ul').hide(); });
 
     $('#workers .group').live('click', function() { $(this).hasClass('open') ? $(this).removeClass('open') : $(this).addClass('open'); })
+
+    $('li#tab_recent').click(function () {
+      Travis.left.recent();
+    });
+    $('li#tab_search').click(function () {
+      Travis.left.search();
+    });
   }
 });
 

--- a/app/assets/javascripts/app/controllers/repositories/list.js
+++ b/app/assets/javascripts/app/controllers/repositories/list.js
@@ -38,6 +38,7 @@ Travis.Controllers.Repositories.List = SC.ArrayController.extend({
 
   searchObserver: function() {
     this[this.searchBox.value ? 'search' : 'recent']();
+    this.tabs.toggle('search', this.searchBox.value);
   }.observes('searchBox.value'),
 
   updateTimes: function() {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -173,7 +173,7 @@ caption {
 
     #tab_search {
       display: none;
-      &.active {
+      &.display {
         display: block;
       }
     }


### PR DESCRIPTION
Now after clicking on the Recent tab, content of Recent tab is displayed
and content of Search tab is preserved (after selecting it, previous
search results are displayed).

Search tab appears when search term is entered and disappears when
search term is empty (this behaviour didn't change).
