### PR TITLE
added 'my repositories' feature

### DIFF
--- a/app/assets/javascripts/app.js
+++ b/app/assets/javascripts/app.js
@@ -73,6 +73,9 @@ var Travis = SC.Application.create({
     $('li#tab_recent').click(function () {
       Travis.left.recent();
     });
+    $('li#tab_my_repositories').click(function() {
+      Travis.left.owned_by($(this).data('github-id'));
+    });
     $('li#tab_search').click(function () {
       Travis.left.search();
     });

--- a/app/assets/javascripts/app/controllers/repositories/list.js
+++ b/app/assets/javascripts/app/controllers/repositories/list.js
@@ -30,6 +30,11 @@ Travis.Controllers.Repositories.List = SC.ArrayController.extend({
     this.set('content', Travis.Repository.recent());
     this.tabs.activate('recent');
   },
+  
+  owned_by: function(githubId) {
+    this.set('content', Travis.Repository.owned_by(githubId));
+    this.tabs.activate('my_repositories');
+  },
 
   search: function() {
     this.set('content', Travis.Repository.search(this.searchBox.value));

--- a/app/assets/javascripts/app/models/repository.js
+++ b/app/assets/javascripts/app/models/repository.js
@@ -64,6 +64,10 @@ Travis.Repository.reopenClass({
   recent: function() {
     return this.all({ orderBy: 'lastBuildStartedAt DESC' });
   },
+  
+  owned_by: function(githubId) {
+    return Travis.store.find(SC.Query.remote(Travis.Repository, { url: 'repositories.json?owner_name=' + githubId, orderBy: 'name' }));
+  },
 
   search: function(search) {
     return Travis.store.find(SC.Query.remote(Travis.Repository, { url: 'repositories.json?search=' + search, orderBy: 'name' }));

--- a/app/assets/javascripts/app/templates/repositories/list.jst.hjs
+++ b/app/assets/javascripts/app/templates/repositories/list.jst.hjs
@@ -7,3 +7,8 @@
   </p>
   <span class="indicator"></span>
 {{/collection}}
+
+{{^collection contentBinding="repositories" id="no_repositories"}}
+  <p>There are no repositories</p>
+	<p class="small"><a href="/profile">Add your repositories to Travis CI</a></p>
+{{/collection}}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -179,6 +179,27 @@ caption {
     }
   }
 
+  #no_repositories {
+    background: transparent;
+    color: #000;
+    text-align: center;
+    padding: 15px 25px 15px 45px !important;
+    
+    .small {
+      color: #666;
+      font-size: 12px;
+      
+      a {
+        color: #777;
+        text-decoration: underline;
+        
+        &:hover {
+         text-decoration: none; 
+        }
+      }
+    }
+  }
+
   #repositories {
     li {
       position: relative;
@@ -338,15 +359,18 @@ caption {
   .tabs li {
     white-space: nowrap;
   }
+  .tabs li:not(.active) {
+    display: none;
+  }
   .tab {
     padding-left: 12px;
   }
   #tab_parent {
     display: none;
   }
-  #tab_build:not(.active) {
-    display: none;
-  }
+//  #tab_build:not(.active) {
+//    display: none;
+//  }
   .tools {
     display: block;
     float: right;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,7 +17,7 @@
     <%= render :partial => 'layouts/assets' %>
   </head>
 
-  <body id="<%= body_id %>">
+  <body id="<%= body_id %>">	
     <%= render 'layouts/top' %>
 
     <div id="left">
@@ -30,12 +30,12 @@
           <h5><a href="#">Recent</a></h5>
           <div class="tab"></div>
         </li>
-        <li id="tab_search">
-          <h5><a href="#">Search</a></h5>
-          <div class="tab"></div>
-        </li>
-        <li id="tab_yours">
-          <h5><a class="tool-tip" title="Not yet implemented. We could use your help!">Your Repositories</a></h5>
+				<li id="tab_my_repositories" data-github-id="<%= current_user.login %>">
+					<h5><a href="#">My Repositories</a></h5>
+					<div class="tab"></div>
+				</li>
+				<li id="tab_search">
+          <h5><a href="#">Results</a></h5>
           <div class="tab"></div>
         </li>
       </ul>


### PR DESCRIPTION
I got sick of the little tooltip, so I took a few hours and hacked together a solution. This pull request allows users to view the repositories that they "own" (where `:owner_name => github_login`) on github that are in Travis.
