### PR TITLE
Add dependency status to README via Gemnasium

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -97,6 +97,10 @@ $ rake travis:create_admin_user
 
 Application is now up & running on **http://localhost:5000**
 
+h2. Dependency Status
+
+"!https://gemnasium.com/travis-ci/travis-ci.png?travis!":https://gemnasium.com/travis-ci/travis-ci
+
 h2. Design Iterations
 
 * "Second design Feb 2010":https://skitch.com/svenfuchs/rtfas/travis.2


### PR DESCRIPTION
A good way to stay up-to-date on Travis' gem dependencies (very close, currently)
