### PR TITLE
Some github stats links fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ vendor/htmlunit
 *~
 \#*
 .rbx/*
+.idea/

--- a/app/assets/javascripts/app/templates/repositories/show.jst.hjs
+++ b/app/assets/javascripts/app/templates/repositories/show.jst.hjs
@@ -6,8 +6,8 @@
 
   <ul class="github-stats">
     <li class="language">{{repository.last_build_language}}</li>
-    <li><a class="watchers" {{bindAttr href="repository.urlGithubWatchers"}}></a></li>
-    <li><a class="forks" {{bindAttr href="repository.urlGithubNetwork"}}></a></li>
+    <li><a class="watchers" title="Watches" {{bindAttr href="repository.urlGithubWatchers"}}></a></li>
+    <li><a class="forks" title="Forks" {{bindAttr href="repository.urlGithubNetwork"}}></a></li>
   </ul>
 
   <ul class="tabs">

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -276,8 +276,9 @@ caption {
     position: relative;
   }
   h3 {
-    margin: 15px 0 0 0;
+    margin: 15px 60px 0 0;
     font-size: 24px;
+    line-height: 24px;
   }
   a {
     color: #666;
@@ -295,7 +296,7 @@ caption {
     position: absolute;
     top: 0;
     right: 0;
-    z-index: 60;
+    z-index: 110;
     a {
       height: 16px;
       display: block;


### PR DESCRIPTION
- increase z-index of github stats links, because stats icons are overlaid by ribbon when sidebar is minimized.
- add right margin for repository heading which is overlaid by github stats links. 
- set line-height for nice multiline repository heading. add .idea/ to .gitignore
