### PR TITLE
Fix client specs.

### DIFF
--- a/spec/client/spec_helper.rb
+++ b/spec/client/spec_helper.rb
@@ -1,9 +1,4 @@
-Dir['spec/client/support/**/*.rb'].sort.each { |path| require File.expand_path(path) }
-
 require 'spec_helper'
-require 'rspec'
-require 'capybara/rspec'
-require 'webmock'
 
 RSpec.configure do |config|
   config.before :each, :js => true do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,7 +24,9 @@ def configure
   require 'patches/rspec_hash_diff'
   require 'rspec/rails'
   require 'webmock'
+
   require_all 'spec/support/**/*.rb', :relative_to => 'spec'
+  require_all 'spec/client/support/**/*.rb', :relative_to => 'spec'
 
   require 'travis/support'
   require 'stringio'


### PR DESCRIPTION
While running full tests suit client side specs are failed with the following errors:

```
Failures:

  1) Service hooks 
  As a registered user
  I want to review my repositories and easily turn service hooks on and off
 my repositories
     Failure/Error: mock_omniauth
     NameError:
       undefined local variable or method `mock_omniauth' for #<RSpec::Core::ExampleGroup::Nested_4:0xb6e6a1c>
     # ./spec/client/service_hooks_spec.rb:9:in `block (2 levels) in <top (required)>'

  2) Queueing and dequeuing builds 
  As anybody
  I want to see which build jobs are queued
 build gets queued
     Failure/Error: dispatch_pusher_command 'jobs', 'build:queued', build_queued_event_info
     NoMethodError:
       undefined method `dispatch_pusher_command' for #<RSpec::Core::ExampleGroup::Nested_5:0xb822bb0>
     # ./spec/client/events/job_queue_spec.rb:24:in `block (2 levels) in <top (required)>'

  3) Queueing and dequeuing builds 
  As anybody
  I want to see which build jobs are queued
 build is removed from queue
     Failure/Error: dispatch_pusher_command 'jobs', 'build:queued', build_queued_event_info
     NoMethodError:
       undefined method `dispatch_pusher_command' for #<RSpec::Core::ExampleGroup::Nested_5:0xb0b3d20>
     # ./spec/client/events/job_queue_spec.rb:32:in `block (2 levels) in <top (required)>'
```

I believe it's caused by helpers from `spec/client/support` not being included into rspec configuration. 

While running specs `specs/spec_helper` is loaded first, requires all helpers from `spec/support` and [includes them](https://github.com/travis-ci/travis-ci/blob/master/spec/spec_helper.rb#L40) into rspec configuration. But as `spec/client/spec_helper` is loaded later helpers from `spec/client/support` that it [requires](https://github.com/travis-ci/travis-ci/blob/master/spec/client/spec_helper.rb#L1) are not included into configuration. Requiring these helpers directly in `specs/spec_helper` fixes the problem.
