### PR TITLE
Do not move list items when revealing repository description.

### DIFF
--- a/app/assets/javascripts/app.js
+++ b/app/assets/javascripts/app.js
@@ -81,12 +81,12 @@ var Travis = Ember.Application.create({
       Travis.left.search();
     });
 
-    $('.slug').live('mouseover', function() { 
-      $(this).siblings('.description').show();
+    $('.repository').live('mouseover', function() {
+      $(this).find('.description').show();
     });
 
-    $('.slug').live('mouseout', function() { 
-      $(this).siblings('.description').hide();
+    $('.repository').live('mouseout', function() {
+      $(this).find('.description').hide();
     });
   },
 

--- a/app/assets/javascripts/app/templates/repositories/list.jst.hjs
+++ b/app/assets/javascripts/app/templates/repositories/list.jst.hjs
@@ -1,12 +1,14 @@
 {{#collection tagName="ul" id="repositories" contentBinding="repositories" itemViewClass="Ember.View" itemClassBinding="content.cssClasses"}}
-  <a {{bindAttr href="content.urlCurrent"}} class="slug">{{content.slug}}</a>
-  <a {{bindAttr href="content.urlLastBuild"}} class="build">#{{content.last_build_number}}</a>
-  <p class="summary">
-    <span class="duration_label">Duration:</span> <abbr class="duration" {{bindAttr title="content.last_build_started_at"}}>{{content.formattedLastBuildDuration}}</abbr>,
-    <span class="finished_at_label">Finished:</span> <abbr class="finished_at timeago" {{bindAttr title="content.last_build_finished_at"}}>{{content.formattedLastBuildFinishedAt}}</abbr>
-  </p>
-  <p class="description">{{content.description}}</p>
-  <span class="indicator"></span>
+  <div class="wrapper">
+    <a {{bindAttr href="content.urlCurrent"}} class="slug">{{content.slug}}</a>
+    <a {{bindAttr href="content.urlLastBuild"}} class="build">#{{content.last_build_number}}</a>
+    <p class="summary">
+      <span class="duration_label">Duration:</span> <abbr class="duration" {{bindAttr title="content.last_build_started_at"}}>{{content.formattedLastBuildDuration}}</abbr>,
+      <span class="finished_at_label">Finished:</span> <abbr class="finished_at timeago" {{bindAttr title="content.last_build_finished_at"}}>{{content.formattedLastBuildFinishedAt}}</abbr>
+    </p>
+    <p class="description">{{content.description}}</p>
+    <span class="indicator"></span>
+  </div>
 {{/collection}}
 
 {{^collection contentBinding="repositories" id="list" class="loading"}}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -183,16 +183,26 @@ caption {
   #repositories {
     li {
       position: relative;
+      font-size: 16px;
+      height: 75px;
+      overflow: visible;
+      &:hover {
+        z-index: 1000;
+      }
+    }
+    li .wrapper {
       padding: 15px 25px 15px 45px !important;
       border-bottom: 1px solid #ccc;
-      font-size: 16px;
       background-position: 24px 16px;
       background-repeat: no-repeat;
+      &:hover {
+        @include single-box-shadow(rgba(black, 0.3), 0px, 3px, 5px);
+      }
     }
-    li:nth-child(odd) {
+    li:nth-child(odd) .wrapper {
       background-color:#fff;
     }
-    li:nth-child(even) {
+    li:nth-child(even) .wrapper {
       background-color:#f6f6f6;
     }
     li.green a {
@@ -233,7 +243,7 @@ caption {
   }
 }
 
-#left #repositories li,
+#left #repositories li .wrapper,
 #main .summary .number a,
 #main #builds td:first-child a,
 #main #builds .build td:first-child a {
@@ -241,7 +251,7 @@ caption {
   padding-left: 20px;
   background-repeat: no-repeat;
 }
-#left #repositories li.green,
+#left #repositories li.green .wrapper,
 #main .green .summary .number a,
 #main #builds .green td:first-child a,
 #main #builds .build.green td:first-child a {
@@ -250,7 +260,7 @@ caption {
   padding-left: 20px;
   background-repeat: no-repeat;
 }
-#left #repositories li.red,
+#left #repositories li.red .wrapper,
 #main .red .summary .number a,
 #main #builds .red td:first-child a,
 #main #builds .build.red td:first-child a {


### PR DESCRIPTION
Make repository description overflow next list item instead of expanding height of the current one:

![Description overflow](http://i.minus.com/idDbFSD8d5KS9.png)

That prevents 'jumping' of items in the repositories list.
