### PR TITLE
Mark current repository as selected.

### DIFF
--- a/app/assets/javascripts/app/controllers/repositories/show.js
+++ b/app/assets/javascripts/app/controllers/repositories/show.js
@@ -62,5 +62,9 @@ Travis.Controllers.Repositories.Show = Ember.Object.extend({
       element.find('.forks').attr('href',repository.get('urlGithubNetwork')).text(data.repository.forks);
       element.find('.github-admin').attr('href', repository.get('urlGithubAdmin'));
     });
-  }.observes('repository.slug')
+  }.observes('repository.slug'),
+
+  repositoryDidChange: function() {
+    this.repository.select();
+  }.observes('repository')
 });


### PR DESCRIPTION
Looks like this indicator was broken long ago. It marks current repository with an arrow:

![Current repository indicator](http://i.minus.com/iYsvOT9GHDxty.png)

It's my first encounter with ember.js as well as any JS framework at all, so it'd be nice if someone with more knowledge can confirm whether it's the right way to go.

I honestly tried to write a test case for that, but I didn't find controllers specs in the project and in views specs looks like that `repositoryDidChange` method is not called at all. I tried updating `repository` property of the view, but that didn't trigger this observer. Can someone help me with that?
