### PR TITLE
Show status image codes.

### DIFF
--- a/app/assets/javascripts/app.js
+++ b/app/assets/javascripts/app.js
@@ -88,6 +88,24 @@ var Travis = Ember.Application.create({
     $('.repository').live('mouseout', function() {
       $(this).find('.description').hide();
     });
+
+    $('.status-image').live('mouseover', function() {
+      if ($(this).find('select').children().length > 0) {
+        $(this).find('.content').fadeIn('fast');
+      }
+    }).find('.content').live('click', function(event){
+      event.stopPropagation();
+    }).find('input[type=text]').live('focus', function() {
+      this.select();
+    }).live('mouseup', function(e) {
+      e.preventDefault();
+    });
+
+    $('html').click(function(e) {
+      if ($(e.target).closest('.status-image .content').length == 0 && $('.status-image .content').css('display') != 'none') {
+        $('.status-image .content').fadeOut('fast');
+      }
+    });
   },
 
   startLoading: function() {

--- a/app/assets/javascripts/app/controllers/repositories/show.js
+++ b/app/assets/javascripts/app/controllers/repositories/show.js
@@ -25,6 +25,9 @@ Travis.Controllers.Repositories.Show = Ember.Object.extend({
       templateName: 'app/templates/repositories/show'
     });
     this.view.appendTo('#main');
+
+    this.branchSelector = '.status-image select';
+    $(this.branchSelector).live('change', this._updateStatusImageCodes.bind(this));
   },
 
   activate: function(tab, params) {
@@ -63,6 +66,37 @@ Travis.Controllers.Repositories.Show = Ember.Object.extend({
       element.find('.github-admin').attr('href', repository.get('urlGithubAdmin'));
     });
   }.observes('repository.slug'),
+
+  _updateGithubBranches: function() {
+    var repository = this.get('repository');
+    if (!repository) return;
+
+    var selector = $(this.branchSelector);
+    selector.children().remove();
+
+    $.getJSON('http://github.com/api/v2/json/repos/show/' + repository.get('slug') + '/branches?callback=?', function(data) {
+      if (selector.children().length == 0) {
+        $.each($.map(data['branches'], function(commit, name) { return name; }).sort(), function(index, branch) {
+          $('<option>', { value: branch }).html(branch).appendTo(selector);
+        });
+        selector.val('master');
+        this._updateStatusImageCodes();
+      }
+    }.bind(this));
+  }.observes('repository.slug'),
+
+  _updateStatusImageCodes: function() {
+    $('.status-image input.url').val(this.get('_statusImageUrl'));
+    $('.status-image input.markdown').val('[![Build Status](' + this.get('_statusImageUrl') + ')](' + this.get('_repositoryUrl') + ')');
+  },
+
+  _statusImageUrl: function() {
+    return 'https://secure.travis-ci.org/' + this.repository.get('slug') + '.png?branch=' + $(this.branchSelector).val();
+  }.property('repository.slug'),
+
+  _repositoryUrl: function() {
+    return 'http://travis-ci.org/' + this.repository.get('slug');
+  }.property('repository.slug'),
 
   repositoryDidChange: function() {
     this.repository.select();

--- a/app/assets/javascripts/app/models/repository.js
+++ b/app/assets/javascripts/app/models/repository.js
@@ -76,6 +76,10 @@ Travis.Repository = Travis.Record.extend(Travis.Helpers.Common, {
   urlGithubAdmin: function() {
     return this.get('url') + '/admin/hooks#travis_minibucket';
   }.property('slug').cacheable(),
+
+  urlStatusImage: function() {
+    return this.get('slug') + '.png'
+  }.property('slug').cacheable()
 });
 
 Travis.Repository.reopenClass({

--- a/app/assets/javascripts/app/templates/repositories/show.jst.hjs
+++ b/app/assets/javascripts/app/templates/repositories/show.jst.hjs
@@ -1,7 +1,16 @@
 <div id="repository">
-  <h3>
+  <div class="title">
     <a {{bindAttr href="repository.urlGithub"}}>{{repository.slug}}</a>
-  </h3>
+    <div class="status-image">
+      <img {{bindAttr src="repository.urlStatusImage"}} alt="Status image"/>
+      <div class="content">
+        <p><span>Branch:</span><select></select></p>
+        <p><span>Image URL:</span><input type="text" class="url"></input></p>
+        <p><span>Markdown:</span><input type="text" class="markdown"></input></p>
+      </div>
+    </div>
+  </div>
+
   <p class="description">{{repository.description}}</p>
 
   <ul class="github-stats">

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -289,10 +289,47 @@ caption {
   #repository {
     position: relative;
   }
-  h3 {
+  .title {
     margin: 15px 60px 0 0;
-    font-size: 24px;
-    line-height: 24px;
+    a {
+      font-size: 24px;
+      line-height: 24px;
+    }
+    .status-image {
+      position: relative;
+      display: inline;
+      margin-left: 10px;
+
+      .content {
+        background-color: #F2F4F9;
+        border: 1px solid #CCC;
+        padding: 10px 20px;
+        font-size: 80%;
+        color: #666;
+        position: absolute;
+        top: 100%;
+        left: 0;
+        z-index: 1000;
+        width: 500px;
+        display: none;
+
+        p {
+          margin: 10px 0;
+
+          span {
+            width: 80px;
+            display: inline-block;
+          }
+
+          input {
+            border: 1px solid #DDD;
+            @include border-radius(3px);
+            width: 410px;
+            padding: 4px;
+          }
+        }
+      }
+    }
   }
   a {
     color: #666;


### PR DESCRIPTION
I made some initial steps to resolve #381 and #404. I added main status image to the right of the repository name. Hovering over this image reveals form with branch selector and a number of fields (currently only two of them) that are refilled with proper url and mardown code when you select a branch. Mouse click on the input selects its content so all that left for user to do is to copy it. The whole block hides when you click anywhere outside of it. Here is how it looks (click for full-size image):

[![Status image codes](http://i.minus.com/ibeQd9OQWBbHdP.png)](http://min.us/mUsGhrWlg#5o)

I think there are several things that can be improved:
- Hopefully someone will be pleasantly surprised when he reaches out for the status image to copy its link and get this form displayed, but when it's hidden there is no hint of its existence. I tried some arrow like button to the right of the image but it didn't look well. May be there should be some small text note though it might not fit nice into this place
- The form is displayed on hover and is hidden on click (outside of it) that is a bit awkward. First I tried showing it on image's `mouseenter` and hiding on form's `mouseleave` but get into troubles with long list of branches. In that case select options list goes out of the box's boundary and click on the option that is outside triggers `mouseleave` on the box.
- Looks like click on the repository in the list on the left of the page causes `repository.slug` to change multiple times that leads to at least two calls of `_updateGithubBranches` and as the result - two API calls to Github. Obviously, it's should be fixed but I'm not sure what is the best way to deal with that.
- A couple of other popular formats like Textile or RDoc should be added.
- Some things might be not in the right places as I'm still getting familiar with project's structure and ember.js architecture. Feel free to point such things out.
- It lacks specs, but I don't know how to mock API calls in JS specs and not sure whether that should be view or controller specs.

I'd appreciate any comments to the implementation and ideas of how to make this feature better. I'll be happy to polish it until it's good enough for merging.
