### PR TITLE
remove duplicates in devise translation

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -124,48 +124,6 @@ en:
       build_count: Build Count
       last_month: last month
       total_builds: Total Builds
-  devise:
-    confirmations:
-      confirmed: Your account was successfully confirmed. You are now signed in.
-      send_instructions: You will receive an email with instructions about how to
-        confirm your account in a few minutes.
-    failure:
-      inactive: Your account was not activated yet.
-      invalid: Invalid email or password.
-      invalid_token: Invalid authentication token.
-      locked: Your account is locked.
-      timeout: Your session expired, please sign in again to continue.
-      unauthenticated: You need to sign in or sign up before continuing.
-      unconfirmed: You have to confirm your account before continuing.
-    mailer:
-      confirmation_instructions:
-        subject: Confirmation instructions
-      reset_password_instructions:
-        subject: Reset password instructions
-      unlock_instructions:
-        subject: Unlock Instructions
-    passwords:
-      send_instructions: You will receive an email with instructions about how to
-        reset your password in a few minutes.
-      updated: Your password was changed successfully. You are now signed in.
-    registrations:
-      destroyed: Bye! Your account was successfully cancelled. We hope to see you
-        again soon.
-      signed_up: You have signed up successfully. If enabled, a confirmation was sent
-        to your e-mail.
-      updated: You updated your account successfully.
-    sessions:
-      signed_in: Signed in successfully.
-      signed_out: Signed out successfully.
-    unlocks:
-      send_instructions: You will receive an email with instructions about how to
-        unlock your account in a few minutes.
-      unlocked: Your account was successfully unlocked. You are now signed in.
-  errors:
-    messages:
-      already_confirmed: was already confirmed
-      not_found: not found
-      not_locked: was not locked
   number:
     human:
       decimal_units:


### PR DESCRIPTION
Translations for Devise exists devise.en.yml and in default en.yml. I suggest to leave devise.en.yml as default
