### PR TITLE
Use Date.current (app TZ aware) instead of Date.today.

### DIFF
--- a/spec/lib/statistics_spec.rb
+++ b/spec/lib/statistics_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Statistics do
   before { Scenario.default }
-  let(:today) {Date.today.to_s(:date)}
+  let(:today) { Date.current.to_s(:date) }
 
   describe "when listing daily test counts" do
     it "should return the jobs per day" do


### PR DESCRIPTION
`Date.today` uses system timezone while ActiveRecord uses UTC as specified in `application.rb`. That leads to spec failure on non-UTC machine when current date in a local TZ is different from UTC date. Using `Date.current` that relies on app TZ fixes the problem.
