### PR TITLE
Updated Gemfile to fix syntax

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source :rubygems
 
-gem 'travis-core',    git: 'git://github.com/travis-ci/travis-core', require: 'travis/engine'
-gem 'travis-support', git: 'git://github.com/travis-ci/travis-support'
+gem 'travis-core',    :git => 'git://github.com/travis-ci/travis-core', :require => 'travis/engine'
+gem 'travis-support', :git => 'git://github.com/travis-ci/travis-support'
 
 gem 'rails',                '~> 3.2.3'
 gem 'rake',                 '~> 0.9.2.2'
@@ -17,15 +17,15 @@ gem 'unobtrusive_flash',    '~> 0.0.2'
 gem 'json',                 '~> 1.6.3'
 gem 'yajl-ruby',            '~> 1.1.0'
 gem 'rabl',                 '~> 0.5.1'
-gem 'rack-contrib', git: 'git://github.com/rack/rack-contrib', require: 'rack/contrib'
+gem 'rack-contrib', :git => 'git://github.com/rack/rack-contrib', :require => 'rack/contrib'
 
 # db
 gem 'pg',                   '~> 0.13.2'
 
 # apis + metrics
 gem 'backports',            '~> 2.3.0'
-gem 'gh',           git: 'git://github.com/rkh/gh'
-gem 'hubble',       git: 'git://github.com/mattmatt/hubble'
+gem 'gh',           :git => 'git://github.com/rkh/gh'
+gem 'hubble',       :git => 'git://github.com/mattmatt/hubble'
 gem 'newrelic_rpm',         '~> 3.3.0'
 gem 'lograge',              '~> 0.0.4'
 
@@ -51,7 +51,7 @@ group :development, :test do
   gem 'forgery',            '~> 0.5.0'
   gem 'rspec-rails',        '~> 2.8.0'
   gem 'thin',               '~> 1.3.1'
-  gem 'localeapp-i18n-js',  git: 'git://github.com/randym/localeapp-i18n-js'
+  gem 'localeapp-i18n-js',  :git => 'git://github.com/randym/localeapp-i18n-js'
 end
 
 group :development do
@@ -60,12 +60,12 @@ group :development do
   unless RUBY_VERSION == '1.9.3' && RUBY_PLATFORM !~ /darwin/
     # will need to install ruby-debug19 manually:
     # gem install ruby-debug19 -- --with-ruby-include=$rvm_path/src/ruby-1.9.3-preview1
-    gem 'ruby-debug19', platforms: :mri_19
+    gem 'ruby-debug19', :platforms => :mri_19
   end
 end
 
 group :test do
-  gem 'jasmine',           git: 'git://github.com/pivotal/jasmine-gem', submodules: true
+  gem 'jasmine',           :git => 'git://github.com/pivotal/jasmine-gem', :submodules => true
   gem 'capybara',          '~> 1.1.2'
   gem 'database_cleaner',  '~> 0.7.0'
   gem 'mocha',             '~> 0.10.0'


### PR DESCRIPTION
Hey Guys, 

The Gemfile seems to have bad syntax. Ive fixed it according to : http://gembundler.com/man/gemfile.5.html

Here's the test of the working one : 

```
/root/travis-ci/Gemfile:3: syntax error, unexpected ':', expecting $end
gem 'travis-core',    git: 'git://github.com/travis-ci/t...
                          ^ (SyntaxError)
       /usr/lib/ruby/gems/1.8/gems/bundler-1.1.3/lib/bundler/definition.rb:18:in `build'
       /usr/lib/ruby/gems/1.8/gems/bundler-1.1.3/lib/bundler.rb:135:in `definition'
       /usr/lib/ruby/gems/1.8/gems/bundler-1.1.3/lib/bundler/cli.rb:220:in `install'
       /usr/lib/ruby/gems/1.8/gems/bundler-1.1.3/lib/bundler/vendor/thor/task.rb:22:in `send'
       /usr/lib/ruby/gems/1.8/gems/bundler-1.1.3/lib/bundler/vendor/thor/task.rb:22:in `run'
       /usr/lib/ruby/gems/1.8/gems/bundler-1.1.3/lib/bundler/vendor/thor/invocation.rb:118:in `invoke_task'
       /usr/lib/ruby/gems/1.8/gems/bundler-1.1.3/lib/bundler/vendor/thor.rb:263:in `dispatch'
       /usr/lib/ruby/gems/1.8/gems/bundler-1.1.3/lib/bundler/vendor/thor/base.rb:386:in `start'
       /usr/lib/ruby/gems/1.8/gems/bundler-1.1.3/bin/bundle:13
       /usr/local/bin/bundle:19:in `load'
       /usr/local/bin/bundle:19
There was an error in your Gemfile, and Bundler cannot continue.
root@travis-ci-n01:~/travis-ci# git pull origin master
remote: Counting objects: 5, done.
remote: Compressing objects: 100% (1/1), done.
remote: Total 3 (delta 2), reused 3 (delta 2)
Unpacking objects: 100% (3/3), done.
From git://github.com/neogenix/travis-ci
 * branch            master     -> FETCH_HEAD
Updating 2b8baf3..2ccba1b
Fast-forward
 Gemfile |   16 ++++++++--------
 1 files changed, 8 insertions(+), 8 deletions(-)
root@travis-ci-n01:~/travis-ci# bundle install 
Fetching gem metadata from http://rubygems.org/.......
```

Let me know if you have any questions! 
