### PR TITLE
Use debugger instead of ruby-debug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,12 +54,7 @@ end
 
 group :development do
   gem 'foreman',            '~> 0.36.0'
-
-  unless RUBY_VERSION == '1.9.3' && RUBY_PLATFORM !~ /darwin/
-    # will need to install ruby-debug19 manually:
-    # gem install ruby-debug19 -- --with-ruby-include=$rvm_path/src/ruby-1.9.3-preview1
-    gem 'ruby-debug19', platforms: :mri_19
-  end
+  gem 'debugger', platforms: :mri_19
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,7 +103,6 @@ GEM
       i18n (~> 0.6)
       multi_json (~> 1.0)
     addressable (2.2.8)
-    archive-tar-minitar (0.5.2)
     arel (3.0.2)
     atomic (1.0.1)
     avl_tree (1.1.3)
@@ -136,6 +135,13 @@ GEM
       activerecord
       rake
     database_cleaner (0.7.2)
+    debugger (1.1.4)
+      columnize (>= 0.3.1)
+      debugger-linecache (~> 1.1.1)
+      debugger-ruby_core_source (~> 1.1.3)
+    debugger-linecache (1.1.1)
+      debugger-ruby_core_source (>= 1.1.1)
+    debugger-ruby_core_source (1.1.3)
     devise (2.0.4)
       bcrypt-ruby (~> 3.0)
       orm_adapter (~> 0.0.3)
@@ -168,8 +174,6 @@ GEM
     kgio (2.7.4)
     libwebsocket (0.1.3)
       addressable
-    linecache19 (0.5.13)
-      ruby_core_source (>= 0.1.4)
     lograge (0.0.4)
       actionpack
       activesupport
@@ -257,16 +261,6 @@ GEM
       activesupport (>= 3.0)
       railties (>= 3.0)
       rspec (~> 2.10.0)
-    ruby-debug-base19 (0.11.25)
-      columnize (>= 0.3.1)
-      linecache19 (>= 0.5.11)
-      ruby_core_source (>= 0.1.4)
-    ruby-debug19 (0.11.6)
-      columnize (>= 0.3.1)
-      linecache19 (>= 0.5.11)
-      ruby-debug-base19 (>= 0.11.19)
-    ruby_core_source (0.1.5)
-      archive-tar-minitar (>= 0.5.2)
     rubyzip (0.9.8)
     sass (3.1.19)
     selenium-webdriver (2.22.2)
@@ -322,6 +316,7 @@ DEPENDENCIES
   coffee-script
   compass
   database_cleaner (~> 0.7.0)
+  debugger
   devise (~> 2.0.4)
   execjs (= 1.3.0)
   factory_girl (~> 2.4.0)
@@ -343,7 +338,6 @@ DEPENDENCIES
   rake-pipeline-web-filters!
   refraction (~> 0.2.0)
   rspec-rails (~> 2.10.0)
-  ruby-debug19
   thin (~> 1.3.1)
   travis-assets!
   travis-core!


### PR DESCRIPTION
ruby-debug is hard to install on 1.9.3, debugger is a fork of ruby-debug that fixes those issues
