### PR TITLE
Do not require rspec/rails twice

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,6 @@ require 'capybara/rspec'
 require 'database_cleaner'
 require 'factory_girl'
 require 'patches/rspec_hash_diff'
-require 'rspec/rails'
 require 'webmock'
 require 'stringio'
 


### PR DESCRIPTION
It seems to be introduced with this <a href="https://github.com/travis-ci/travis-ci/commit/8f47c5e1d1b76dcc3ec9a2022f3b57bba54c5e76#L67R26">conflict resolving commit</a>.
