### PR TITLE
Remove the alpha warning.

### DIFF
--- a/app/views/layouts/_about.html.erb
+++ b/app/views/layouts/_about.html.erb
@@ -1,7 +1,3 @@
-<div id="alpha_warning" class="box">
-  <h4><%= t '.alpha' %></h4>
-  <p><%= raw t '.messages.alpha' %></p>
-</div>
 <div id="about" class="box">
   <h4><%= t '.join' %></h4>
   <ul>


### PR DESCRIPTION
Travis has been running for almost 1,5 years now, and I think it's about time to show the confidence that goes along with that and remove the pesky alpha warning. Travis builds thousands of projects every day, it should get a badge that says "Travis: At your service" instead! :)
