### PR TITLE
Travis API :owner_name no longer works for Organizations

### DIFF
--- a/app/controllers/v1/repositories_controller.rb
+++ b/app/controllers/v1/repositories_controller.rb
@@ -27,6 +27,7 @@ module V1
         @repositories ||= begin
           scope = Repository.timeline.recent
           # TODO params[:owner_name] should be :login (as passed from the client)
+          scope = scope.by_member(params[:member])         if params[:member]
           scope = scope.by_owner_name(params[:owner_name]) if params[:owner_name]
           scope = scope.by_slug(params[:slug])             if params[:slug]
           scope = scope.search(params[:search])            if params[:search].present?

--- a/app/controllers/v2/repositories_controller.rb
+++ b/app/controllers/v2/repositories_controller.rb
@@ -22,6 +22,7 @@ module V2
       def repositories
         @repositories ||= begin
           scope = Repository.timeline.recent
+          scope = scope.by_member(params[:member])         if params[:member]
           scope = scope.by_owner_name(params[:owner_name]) if params[:owner_name]
           scope = scope.by_slug(params[:slug])             if params[:slug]
           scope = scope.search(params[:search])            if params[:search].present?

--- a/spec/controllers/v1/repositories_controller_spec.rb
+++ b/spec/controllers/v1/repositories_controller_spec.rb
@@ -19,7 +19,6 @@ describe V1::RepositoriesController do
 
       context 'filtered by owner_name' do
         it 'when owner_name is a user' do
-          Permission.create!(:push => true, :user => User.find_by_login('svenfuchs'), :repository => Repository.find_by_name('enginex'))
           get(:index, :owner_name => 'svenfuchs', :format => :json)
 
           response.should be_success
@@ -37,6 +36,19 @@ describe V1::RepositoriesController do
           result = json_response
           result.count.should  == 1
           result.first['slug'].should == 'travis-ci/enginex'
+        end
+      end
+
+      context 'filtered by member' do
+        it 'should return all repositories that the user has permission to push' do
+          Permission.create!(:push => true, :user => User.find_by_login('svenfuchs'), :repository => Repository.find_by_name('enginex'))
+          get(:index, :member => 'svenfuchs', :format => :json)
+
+          response.should be_success
+          result = json_response
+          result.count.should  == 2
+          result.first['slug'].should == 'svenfuchs/minimal'
+          result.last['slug'].should == 'josevalim/enginex'
         end
       end
     end


### PR DESCRIPTION
It looks like something was broken recently. Hitting a URL like this:

```
/repositories.json?owner_name=sethvargo
```

works, but when trying to view repositories for an organization, it fails:

```
/repositories.json?owner_name=travis-ci
```

If someone points me in the right direction, I'll submit a PR with some tests to ensure it doesn't happen again. I'm not sure where to start though.
