### PR TITLE
minor singular/plural translation error

### DIFF
--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -84,7 +84,7 @@ fr:
       recent: Récent
       search: Chercher
       sponsers: Sponsors
-      sponsors_link: Voir tous nos extraordinaire sponsors &rarr;
+      sponsors_link: Voir tous nos extraordinaires sponsors &rarr;
       my_repositories: Mes dépôts
     about:
       alpha: Ceci est en alpha.


### PR DESCRIPTION
Brought up by "Moosh" on the mailing list, confirmed via Google Translate. =^)
