### PR TITLE
Include IRC channel name in README

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -32,7 +32,7 @@ h3. We Are Not Done Yet
 
 Please note that this is a work in progress. We have only reached our #1 goal so far. We try to follow the 80/20 rule for requirements, i.e., we focus on the most common use cases.
 
-Travis CI is **not** currently a good fit for closed in-house installations: it's made up of multiple applications which evolve rapidly, and its workers require VMs running on the same host. Ask on the "IRC channel":irc://irc.freenode.net#travis for more information.
+Travis CI is **not** currently a good fit for closed in-house installations: it's made up of multiple applications which evolve rapidly, and its workers require VMs running on the same host. Ask on the "IRC channel (travis)":http://webchat.freenode.net?channels=travis&uio=d4 for more information.
 
 You can also watch this (year-old, but still valid) screencast to get an idea of how Travis works: "1:20 quick demo screencast (spike 2)":http://www.youtube.com/watch?v=mNOwCJhjWAw
 
@@ -41,7 +41,7 @@ h2. Get In Touch!
 
 * "Github":http://github.com/travis-ci
 * "Twitter":http://twitter.com/travisci
-* "IRC":irc://irc.freenode.net#travis
+* "IRC (travis)":http://webchat.freenode.net?channels=travis&uio=d4
 * "Mailing list":http://groups.google.com/group/travis-ci
 
 


### PR DESCRIPTION
Currently the links to the IRC channel just use the `irc://` link, but that renders as blank for me. 

I added the IRC channel name explicitly so that users without an IRC client can still read off the channel name.
