### PR TITLE
readme: point travis-worker to github repo

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -169,7 +169,7 @@ Please keep in mind that Travis CI evolves rapidly and developer documentation
 may be outdated. (Pull requests are welcome.) Development, [travis-ci.org]
 (https://travis-ci.org) maintenance, and user documentation take priority.
 
-- [travis worker](http://about.travis-ci.org/docs/dev/worker/)
+- [travis worker](https://github.com/travis-ci/travis-worker)
 
 
 ## What Is This Repository?


### PR DESCRIPTION
$ curl -i about.travis-ci.org/docs/dev/worker/
HTTP/1.1 404 Not Found
Server: GitHub.com
Content-Type: text/html
Content-Length: 9371
Accept-Ranges: bytes
Date: Mon, 09 Sep 2013 15:18:12 GMT
Via: 1.1 varnish
Age: 0
Connection: keep-alive
X-Served-By: cache-sv63-SJC3
X-Cache: MISS
X-Cache-Hits: 0
X-Timer: S1378739892.310816526,VS0,VE74
Vary: Accept-Encoding
[snip]
