### PR TITLE
[README.md] Use HTTPS link + fix dead link

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -12,7 +12,7 @@ project.
 ## Documentation
 
 Documentation for the Travis CI project can be found at
-<http://docs.travis-ci.com>.
+<https://docs.travis-ci.com>.
 
 ## Other repositories
 
@@ -41,7 +41,7 @@ holds the models, services, and other things that these apps need.
 ### travis-cookbooks
 
 [travis-cookbooks](https://github.com/travis-ci/travis-cookbooks) holds the
-[Chef](http://docs.opscode.com/) cookbooks that are used to provision the build environments.
+[Chef](https://docs.chef.io/index.html) cookbooks that are used to provision the build environments.
 
 ### travis-hub
 
@@ -86,7 +86,7 @@ different notification providers as needed.
 It is written using [Ember](http://emberjs.com) and communicates with
 [travis-api](#travis-api) to get information and gets live updates from
 [travis-hub](#travis-hub) and [travis-logs](#travis-logs) through
-[Pusher](http://pusher.com/).
+[Pusher](https://pusher.com/).
 
 ### travis-worker
 


### PR DESCRIPTION
http://docs.opscode.com/ returns 404 now. Way Back machine shows the link redirected to https://docs.chef.io/index.html in early 2016. So I updated this link in this change. Also updated two more links to use HTTPS for better security and performance (avoiding redirects).