### PR TITLE
Update link to status page in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ We are moving to our new community forum: [Travis CI Community](https://travis-c
 
 Link to the Community Forum: https://travis-ci.community
 
-For current outages and incidents such as slow network connections, subscribe to https://traviscistatus.com.
+For current outages and incidents such as slow network connections, subscribe to https://www.traviscistatus.com.
 
 Other support issues may be directed to support@travis-ci.com where our support team will be glad to assist.
 


### PR DESCRIPTION
The link to https://traviscistatus.com does not resolve. This updates the README to point to the working URL of https://www.traviscistatus.com.

You can close this without merging if the intended behavior is for the version without `www` to work and that is just fixed instead. :smile: 