### PR TITLE
Stale Bot: never close issues with a 'security' label

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -15,6 +15,7 @@ exemptLabels:
   - locked
   - feature-request
   - pinned
+  - security
 
 # Set to true to ignore issues in a project (defaults to false)
 exemptProjects: false


### PR DESCRIPTION
In issues with a `security` label the stale bot can be really annoying (e.g. #9430).
This PR adds the `security` label to the list of exempted labels for the stale bot.